### PR TITLE
switch to black and white basemap style

### DIFF
--- a/www/static/tangram/scene.yaml
+++ b/www/static/tangram/scene.yaml
@@ -1,9 +1,5 @@
-# This style is an homage to Michal Migurski's High Road demo:
-# https://github.com/migurski/HighRoad
-# It uses stops to set line and outline widths at various zoom levels,
-# and the sort_key property to arrange bridges, overpasses, and tunnels
-# by depth.
-#
+﻿# Author: Geraldine Sarmiento, Nathaniel V. Kelso
+# Master: https://github.com/tangrams/multiverse/blob/gh-pages/styles/line-drawing2.yaml
 
 labels-global:
     - &text_visible_continent         true
@@ -12,467 +8,103 @@ labels-global:
     - &label_visible_landuse          true
     - &icon_visible_landuse           true
     - &text_visible_landuse           true
-    - &label_visible_poi              false
-    - &icon_visible_poi               false
-    - &text_visible_poi               false
-    - &text_visible_highway           false
-    - &text_visible_trunk_primary     false
-    - &text_visible_secondary         false
-    - &text_visible_tertiary          false
-    - &text_visible_minor_road        false
-    - &text_visible_service_road      false
-    - &text_visible_path              false
-    - &text_visible_steps             false
+    - &label_visible_poi              true
+    - &icon_visible_poi               true
+    - &text_visible_poi               true
+    - &text_visible_highway           true
+    - &text_visible_trunk_primary     true
+    - &text_visible_secondary         true
+    - &text_visible_tertiary          true
+    - &text_visible_minor_road        true
+    - &text_visible_service_road      true
+    - &text_visible_path              true
+    - &text_visible_steps             true
 
 
 bannana-colors:
-    cameras:
+    cameras:             
         - &camera_settings            { type: isometric, axis: [0, .1], vanishing_point: [0, -500] }
-        
-    lights:
+
+    lights:              
         - &light_settings             { type: directional, direction: [1, 1, -.9], diffuse: 0.5, ambient: 0.85 }
- 
+
+
     styles:
         - &line_type                 flatlines
         - &polygon_type              flatpolys
- 
+
     roads:
-        - &highway1                   '#fc0'
-        - &highway_link1              '#f6e0a1'
-        - &highway_casing1            black
-        - &highway_tunnel1            [0.8, 0.8, 0.7]
-        - &highway_tunnel_casing1     [0.9, 0.9, 0.8]
-        - &highway_link_tunnel_casing1 [0.8, 0.8, 0.7]
-        - &ferry1                     '#8bb5e4'
-        - &major_road1                [1, 1, 1]
-        - &major_road1b               [0.90, 0.90, 0.90]
-        - &major_road2                [0.80, 0.80, 0.80]
-        - &major_road2a               [0.83, 0.83, 0.83]
-        - &major_road2b               [0.75, 0.75, 0.75]
-        - &major_road3                [0.70, 0.70, 0.70]
-        - &major_road4                [0.60, 0.60, 0.60]
-        - &major_casing1              black               # same as highway_casing1
-        - &major_casing2              grey                # zoomed out
-        - &major_tunnel1              '#ffdb99'           # light orange (major_route1)
-        - &major_tunnel_casing1       [0.9, 0.9, 0.8]
-        - &major_route1               orange
-        - &major_route2               orange              # zoomed out
-        - &minor_route                orange              # same as major_route
-        - &minor_road1                [0.60, 0.60, 0.60]  # natural earth
-        - &minor_road2                [0.80, 0.80, 0.80]  # natural earth, same as major_road2
-        - &minor_road3                '#ccc'
-        - &minor_road4                '#868686'           # zoomed out
-        - &minor_road5                '#909090'           # zoomed out, again
-        - &minor_tunnel1              [0.8, 0.8, 0.7]
-        - &minor_tunnel_casing1       white
-        - &service_road1              '#ccc'
-        - &service_road_casing1       grey
-        - &path1                      '#bcc19e'
-        - &path2                      '#c1bc9d'           # zoomed out
-        - &path_casing1               '#5d6b5d'
-        - &path_bridge_casing1        black
-        - &path_bridge_casing2        grey                # zoomed out
-        - &path_steps1                '#bcc19e'
-    
+        - &highway1                   [0.00, 0.00, 0.00]
+        - &highway_link1              [0.00, 0.00, 0.00]
+        - &highway_casing1            [0.40, 0.40, 0.40]
+        - &highway_tunnel1            [0.7, 0.7, 0.7]
+        - &highway_tunnel_casing1     [1.00, 0.00, 0.00]
+        - &highway_link_tunnel_casing1 [1.00, 0.00, 0.00]
+        - &ferry1                     [0.30, 0.30, 0.30]
+        - &major_road1                [0.0, 0.0, 0.0]
+        - &major_road1b               [0.935, 0.935, 0.935]
+        - &major_road2                [0.935, 0.935, 0.935]
+        - &major_road2a               [0.935, 0.935, 0.935]
+        - &major_road2b               [0.935, 0.935, 0.935]
+        - &major_road3                [0.935, 0.935, 0.935]
+        - &major_casing1              [0.40, 0.40, 0.40]  # same as highway_casing1
+        - &major_casing2              [0.40, 0.40, 0.40]                # zoomed out
+        - &major_tunnel1              [0.7, 0.7, 0.7]
+        - &major_tunnel_casing1       [1.00, 0.00, 0.00]
+        - &major_route1               [0.97, 0.97, 0.97]
+        - &major_route2               [0.97, 0.97, 0.97]  # zoomed out
+        - &minor_route                [0.97, 0.97, 0.97]               # same as major_route
+        - &major_road4                [0.00, 0.00, 0.00]
+        - &minor_road1                [0.935, 0.935, 0.935]  # natural earth
+        - &minor_road2                [0.935, 0.935, 0.935]  # natural earth, same as major_road2
+        - &minor_road3                [0.935, 0.935, 0.935]
+        - &minor_road4                [0.935, 0.935, 0.935]              # zoomed out
+        - &minor_road5                [0.935, 0.935, 0.935]          # zoomed out, again
+        - &minor_tunnel1              [0.7, 0.7, 0.7]
+        - &minor_tunnel_casing1       [1.00, 0.00, 0.00]
+        - &service_road1              [0.935, 0.935, 0.935]
+        - &service_road_casing1       [0.40, 0.40, 0.40]
+        - &path1                      [0.97, 0.97, 0.97]
+        - &path2                      [0.97, 0.97, 0.97]  # zoomed out
+        - &path_casing1               [0.40, 0.40, 0.40]
+        - &path_bridge_casing1        [0.40, 0.40, 0.40]
+        - &path_bridge_casing2        [0.40, 0.40, 0.40]  # zoomed out
+        - &path_steps1                red
+
+    boundaries:
+        - &country_boundary           '#ccc'
+        - &region_boundary            '#ccc'
+        - &subregion_boundary         '#ccc'
+
     areas:
-        - &scene1      '#eee'              # map background, water
-        - &water1      [0.83, 0.83, 0.83]  # water
-        - &earth1      '#666'              # land color
-        - &green1      '#6e7e6d'           # park
-        - &green2      '#879886'           # cemetery
-        - &green3      '#8ba289'           # golf course
-        - &green4      '#526054'           # farm faint
-        - &green5      '#5a695c'           # farm
-        - &green6      '#648560'           # nature reserve
-        - &green7      '#647262'           # forest
-        - &orange1     '#bfb08e'           # stadium
-        - &brown1      '#7e7b6d'           # university
-        - &brown2      '#ada497'           # school
-        - &brown3      '#c7b7a2'           # playground
-        - &red1        '#ad8d8d'           # hospital
-        - &grey1       '#717171'           # pedestrian, retail, airport apron, parking, church
+        - &scene1      black               # map background, water
+        - &water1      white               # water
+        - &earth1      white               # land color
+        - &green1      [0.50,0.50,0.50]    # park
+        - &green2      '#949494'           # cemetery
+        - &green3      '#9a9a9a'           # golf course
+        - &green4      [0.90,0.90,0.90]    # farm faint
+        - &green5      [0.75,0.75,0.75]    # farm
+        - &green6      [0.40,0.40,0.40]    # nature reserve
+        - &green7      '#aaaaaa'           # forest
+        - &orange1     '#aaaaaa'           # stadium
+        - &brown1      '#7b7b7b'           # university
+        - &brown2      '#aaaaaa'           # school
+        - &brown3      '#b8b8b8'           # playground
+        - &red1        '#a2a2a2'           # hospital
+        - &grey1       '#cccccc'           # pedestrian, retail, airport apron, parking, church
         - &grey2       [0.5, 0.5, 0.5]     # airport runway
         - &grey3       grey                # railway
-        - &mystry1     '#bfb08e'           # recreation ground
-        - &building1   [.3, .3, .3]        # building
-        - &building2   [.2, .2, .2]        # building stroke
-        - &building_o  5                   # building stroke order
-    
+        - &mystry1     '#aaaaaa'           # recreation ground (type of park, sometimes around reservoirs)
+        - &building1   white               # building
+        - &building2   black               # building stroke
+        - &building_o  25                  # building stroke order
+
     labels:
-        - &text_fill   '#fff'             # WHITE
-        - &text_stroke '#444'             # land color
-    
-#toner-colors:
-#    camera_settings:             &camera_settings            { type: isometric, axis: [0, .1], vanishing_point: [0, -500] }
-#    light_settings:              &light_settings             { type: directional, direction: [1, 1, -.9], diffuse: 0.5, ambient: 0.85 }
-# 
-#    line_type:                    &line_type                 flatlines
-#    polygon_type:                 &polygon_type              flatpolys
-# 
-#    #roads
-#    highway1:                    &highway1                   black
-#    highway_link1:               &highway_link1              [0.3, 0.3, 0.3]
-#    highway_casing1:             &highway_casing1            white
-#    highway_tunnel1:             &highway_tunnel1            [0.8, 0.8, 0.8]
-#    highway_tunnel_casing1:      &highway_tunnel_casing1     [0.95, 0.95, 0.95]
-#    highway_link_tunnel_casing1: &highway_link_tunnel_casing1 [0.95, 0.95, 0.95]
-#    ferry1:                      &ferry1                     [0.30, 0.30, 0.30]
-#    major_road1:                 &major_road1                [0, 0, 0]
-#    major_road1b:                &major_road1b               [0.10, 0.10, 0.10]
-#    major_road2:                 &major_road2                [0.20, 0.20, 0.20]
-#    major_road2a:                &major_road2a               [0.17, 0.17, 0.17]
-#    major_road2b:                &major_road2b               [0.25, 0.25, 0.25]
-#    major_road3:                 &major_road3                [0.30, 0.30, 0.30]
-#    major_casing1:               &major_casing1              white               # same as highway_casing1
-#    major_casing2:               &major_casing2              grey                # zoomed out
-#    major_tunnel1:               &major_tunnel1              grey
-#    major_tunnel_casing1:        &major_tunnel_casing1       [0.95, 0.95, 0.95]
-#    major_route1:                &major_route1               black
-#    major_route2:                &major_route2               [0.40, 0.40, 0.40]  # zoomed out
-#    minor_route:                 &minor_route                black               # same as major_route
-#    major_road4:                 &major_road4                [0.40, 0.40, 0.40]
-#    minor_road1:                 &minor_road1                [0.40, 0.40, 0.40]  # natural earth
-#    minor_road2:                 &minor_road2                [0.20, 0.20, 0.20]  # natural earth, same as major_road2
-#    minor_road3:                 &minor_road3                '#ccc'
-#    minor_road4:                 &minor_road4                '#ccc'              # zoomed out
-#    minor_road5:                 &minor_road5                '#909090'           # zoomed out, again
-#    minor_tunnel1:               &minor_tunnel1              [0.9, 0.9, 0.9]
-#    minor_tunnel_casing1:        &minor_tunnel_casing1       [0.1, 0.1, 0.1]
-#    service_road1:               &service_road1              white
-#    service_road_casing1:        &service_road_casing1       grey
-#    path1:                       &path1                      '#b3b3b3'
-#    path2:                       &path2                      '#b3b3b3'           # zoomed out
-#    path_casing1:                &path_casing1               '#5d6b5d'
-#    path_bridge_casing1:         &path_bridge_casing1        grey
-#    path_bridge_casing2:         &path_bridge_casing2        grey                # zoomed out
-#    path_steps1:                 &path_steps1                grey
-#    
-#    #areas
-#    scene1:     &scene1      black               # map background, water
-#    scene2:     &scene2      0.9,0.9,0.9         # map background, water
-#    water1:     &water1      black               # water
-#    earth1:     &earth1      white               # land color
-#    green1:     &green1      [0.50,0.50,0.50]    # park
-#    green1b:    &green1b     0.80,0.80,0.80      # park
-#    green2:     &green2      '#949494'           # cemetery
-#    green3:     &green3      '#9a9a9a'           # golf course
-#    green4:     &green4      [0.90,0.90,0.90]    # farm faint
-#    green5:     &green5      [0.75,0.75,0.75]    # farm
-#    green6:     &green6      [0.40,0.40,0.40]    # nature reserve
-#    green7:     &green7      '#aaaaaa'           # forest
-#    orange1:    &orange1     '#aaaaaa'           # stadium
-#    brown1:     &brown1      '#7b7b7b'           # university
-#    brown2:     &brown2      '#aaaaaa'           # school
-#    brown3:     &brown3      '#b8b8b8'           # playground
-#    red1:       &red1        '#a2a2a2'           # hospital
-#    grey1:      &grey1       '#cccccc'           # pedestrian, retail, airport apron, parking, church
-#    grey2:      &grey2       [0.5, 0.5, 0.5]     # airport runway
-#    grey3:      &grey3       grey                # railway
-#    mystry1:    &mystry1     '#aaaaaa'           # recreation ground (type of park, sometimes around reservoirs)
-#    building1:  &building1   white               # building
-#    building2:  &building2   black               # building stroke
-#    building_o: &building_o  25                  # building stroke order
-#    
-#    #labels
-#    text_fill:   &text_fill   black              # BLACK
-#    text_stroke: &text_stroke white              # land color
+        - &text_fill   '#000'             # WHITE
+        - &text_fill2  '#000'             # WHITE
+        - &text_stroke '#fff'             # land color
 
-
-#blueprint-colors:
-#    camera_settings:             &camera_settings            { type: perspective, vanishing_point: [0, -500] }
-#    light_settings:              &light_settings             { type: directional, direction: [.1, .5, -1], diffuse: 0.7, ambient: 0.5 }
-#        
-#    water_type:                   &water_type                base
-#    earth_type:                   &earth_type                base
-#    line_type:                    &line_type                 roads
-#    polygon_type:                 &polygon_type              base
-#    building_type:                &building_type             buildings
-#    buildings_line_type:          &buildings_line_type       buildingsLines
-# 
-#    #roads
-#    highway1:                    &highway1                   '#0080c8'     #BLUE
-#    highway_link1:               &highway_link1              '#198ccd'     #90%
-#    highway_casing1:             &highway_casing1            white
-#    highway_tunnel1:             &highway_tunnel1            '#3399d3'     #80%
-#    highway_tunnel_casing1:      &highway_tunnel_casing1     '#0d86cb'     #95%
-#    highway_link_tunnel_casing1: &highway_link_tunnel_casing1 '#0d86cb'    #95%
-#    ferry1:                      &ferry1                     '#8bb5e4'
-#    major_road1:                 &major_road1                '#3399d3'     #80%
-#    major_road1b:                &major_road1b               '#e5f2f9'     #10%
-#    major_road2:                 &major_road2                '#cce6f4'     #20%
-#    major_road2a:                &major_road2a               '#d4eaf6'     #17%
-#    major_road2b:                &major_road2b               '#bfdff1'     #25%
-#    major_road3:                 &major_road3                '#b2d9ee'     #30%
-#    major_casing1:               &major_casing1              white         # same as highway_casing1
-#    major_casing2:               &major_casing2              '#7fbfe3'     #50% - zoomed out
-#    major_tunnel1:               &major_tunnel1              '#3399d3'     #80%
-#    major_tunnel_casing1:        &major_tunnel_casing1       '#0d86cb'     #95%
-#    major_route1:                &major_route1               '#7fbfe3'     #50% warm
-#    major_route2:                &major_route2               '#99cce9'     #40% - zoomed out
-#    minor_route:                 &minor_route                '#7fbfe3'     # same as major_route
-#    major_road4:                 &major_road4                '#99cce9'     #40%
-#    minor_road1:                 &minor_road1                '#99cce9'     #40% - natural earth
-#    minor_road2:                 &minor_road2                '#cce6f4'     #20% - natural earth, same as major_road2
-#    minor_road3:                 &minor_road3                '#cce6f4'     #20%
-#    minor_road4:                 &minor_road4                '#d4eaf6'     #17% - zoomed out
-#    minor_road5:                 &minor_road5                '#e5f2f9'     #10% - zoomed out, again
-#    minor_tunnel1:               &minor_tunnel1              '#3399d3'     #80%
-#    minor_tunnel_casing1:        &minor_tunnel_casing1       '#0d86cb'     #95%
-#    service_road1:               &service_road1              white
-#    service_road_casing1:        &service_road_casing1       '#d4eaf6'     #17%
-#    path1:                       &path1                      '#66b3de'     #60%
-#    path2:                       &path2                      '#7fbfe3'     #50% - zoomed out
-#    path_casing1:                &path_casing1               '#5d6b5d'
-#    path_bridge_casing1:         &path_bridge_casing1        '#7fbfe3'     #50%
-#    path_bridge_casing2:         &path_bridge_casing2        '#7fbfe3'     #50% - zoomed out
-#    path_steps1:                 &path_steps1                '#7fbfe3'     #50%
-#    
-#    #areas
-#    scene1:     &scene1      '#3091c8'              # map background, water
-#    water1:     &water1      '#3091c8'              # water
-#    earth1:     &earth1      white                  # land color
-#    green1:     &green1      '#7fbfe3'              # 50% - park
-#    green2:     &green2      '#99cce9'              # 40% - cemetery
-#    green3:     &green3      '#b2d9ee'              # 30% - golf course
-#    green4:     &green4      '#e5f2f9'              # 10% - farm faint
-#    green5:     &green5      '#bfdff1'              # 25% - farm
-#    green6:     &green6      '#66b3de'              # 60% - nature reserve
-#    green7:     &green7      '#99cce9'              # 40% - forest
-#    orange1:    &orange1     '#99cce9'              # 40% - stadium
-#    brown1:     &brown1      '#3399d3'              # 80% - university
-#    brown2:     &brown2      '#99cce9'              # 40% - school
-#    brown3:     &brown3      '#66b3de'              # 60% - playground
-#    red1:       &red1        '#4ca6d8'              # 70% - hospital
-#    grey1:      &grey1       '#e5f2f9'              # 10% - pedestrian, retail, airport apron, parking, church
-#    grey2:      &grey2       '#7fbfe3'              # 50% - airport runway
-#    grey3:      &grey3       '#b2d9ee'              # 30% - railway
-#    mystry1:    &mystry1     '#99cce9'              # 40% - recreation ground (type of park, sometimes around reservoirs)
-#    building1:  &building1   '#b2d9ee'              # 30% - building
-#    building2:  &building2   '#b2d9ee'              # building stroke
-#    building_o: &building_o  25                     # building stroke order
-#    
-#    #labels
-#    text_fill:   &text_fill   '#0080c8'             # BLUE
-#    text_stroke: &text_stroke white                 # land color
-
-
-#sepia-tone-colors:
-#   camera_settings:             &camera_settings            { type: perspective, vanishing_point: [0, -500] }
-#   light_settings:              &light_settings             { type: directional, direction: [.1, .5, -1], diffuse: 0.7, ambient: 0.5 }
-#       
-#   water_type:                   &water_type                base
-#   earth_type:                   &earth_type                base
-#   line_type:                    &line_type                 roads
-#   polygon_type:                 &polygon_type              base
-#   building_type:                &building_type             buildings
-#   buildings_line_type:          &buildings_line_type       buildingsLines
-# 
-#   #roads
-#   highway1:                    &highway1                   '#706249'     #SEPIA
-#   highway_link1:               &highway_link1              '#8d816d'     #85%
-#   highway_casing1:             &highway_casing1            white
-#   highway_tunnel1:             &highway_tunnel1            '#8d816d'     #80%
-#   highway_tunnel_casing1:      &highway_tunnel_casing1     '#776a52'     #95%
-#   highway_link_tunnel_casing1: &highway_link_tunnel_casing1 '#776a52'    #95%
-#   ferry1:                      &ferry1                     '#8bb5e4'
-#   major_road1:                 &major_road1                '#8d816d'     #80%
-#   major_road1b:                &major_road1b               '#f0efec'     #10%
-#   major_road2:                 &major_road2                '#f0efec'     #20%
-#   major_road2a:                &major_road2a               '#e7e5e0'     #17%
-#   major_road2b:                &major_road2b               '#dbd8d1'     #25%
-#   major_road3:                 &major_road3                '#d4d0c8'     #30%
-#   major_casing1:               &major_casing1              white         # same as highway_casing1
-#   major_casing2:               &major_casing2              '#b7b0a4'     #50% - zoomed out
-#   major_tunnel1:               &major_tunnel1              '#8d816d'     #80%
-#   major_tunnel_casing1:        &major_tunnel_casing1       '#776a52'     #95%
-#   major_route1:                &major_route1               '#a9a192'     #60% warm
-#   major_route2:                &major_route2               '#b7b0a4'     #50% - zoomed out
-#   minor_route:                 &minor_route                '#a9a192'     # same as major_route
-#   major_road4:                 &major_road4                '#c6c0b6'     #40%
-#   minor_road1:                 &minor_road1                '#c6c0b6'     #40% - natural earth
-#   minor_road2:                 &minor_road2                '#f0efec'     #20% - natural earth, same as major_road2
-#   minor_road3:                 &minor_road3                '#f0efec'     #20%
-#   minor_road4:                 &minor_road4                '#e7e5e0'     #17% - zoomed out
-#   minor_road5:                 &minor_road5                '#f0efec'     #10% - zoomed out, again
-#   minor_tunnel1:               &minor_tunnel1              '#8d816d'     #80%
-#   minor_tunnel_casing1:        &minor_tunnel_casing1       '#776a52'     #95%
-#   service_road1:               &service_road1              white
-#   service_road_casing1:        &service_road_casing1       '#e7e5e0'     #17%
-#   path1:                       &path1                      '#a9a192'     #60%
-#   path2:                       &path2                      '#b0a99b'     #55% - zoomed out
-#   path_casing1:                &path_casing1               '#5d6b5d'
-#   path_bridge_casing1:         &path_bridge_casing1        '#b7b0a4'     #50%
-#   path_bridge_casing2:         &path_bridge_casing2        '#b7b0a4'     #50% - zoomed out
-#   path_steps1:                 &path_steps1                '#b7b0a4'     #50%
-#   
-#   #areas
-#   scene1:     &scene1      '#cfc8ba'              # map background, water
-#   water1:     &water1      '#cfc8ba'              # water
-#   earth1:     &earth1      white                  # land color
-#   green1:     &green1      '#b7b0a4'              # 50% - park
-#   green2:     &green2      '#c6c0b6'              # 40% - cemetery
-#   green3:     &green3      '#d4d0c8'              # 30% - golf course
-#   green4:     &green4      '#f0efec'              # 10% - farm faint
-#   green5:     &green5      '#dbd8d1'              # 25% - farm
-#   green6:     &green6      '#a9a192'              # 60% - nature reserve
-#   green7:     &green7      '#c6c0b6'              # 40% - forest
-#   orange1:    &orange1     '#c6c0b6'              # 40% - stadium
-#   brown1:     &brown1      '#8d816d'              # 80% - university
-#   brown2:     &brown2      '#c6c0b6'              # 40% - school
-#   brown3:     &brown3      '#a9a192'              # 60% - playground
-#   red1:       &red1        '#9b917f'              # 70% - hospital
-#   grey1:      &grey1       '#f0efec'              # 10% - pedestrian, retail, airport apron, parking, church
-#   grey2:      &grey2       '#b7b0a4'              # 50% - airport runway
-#   grey3:      &grey3       '#d4d0c8'              # 30% - railway
-#   mystry1:    &mystry1     '#c6c0b6'              # 40% - recreation ground (type of park, sometimes around reservoirs)
-#   building1:  &building1   '#d4d0c8'              # 30% - building
-#   building2:  &building2   '#706249'              # building stroke
-#   building_o: &building_o  25                     # building stroke order
-#   
-#   #labels
-#   text_fill:   &text_fill   '#706249'             # SEPIA
-#   text_stroke: &text_stroke white                 # land color
-
-
-#data-exploration-colors:
-#    camera_settings:             &camera_settings            { type: isometric, axis: [0, .1], vanishing_point: [0, -500] }
-#    light_settings:              &light_settings             { type: directional, direction: [1, 1, -.9], diffuse: 0.5, ambient: 0.85 }
-# 
-#    line_type:                    &line_type                 flatlines
-#    polygon_type:                 &polygon_type              flatpolys
-# 
-#    #roads
-#    highway1:                    &highway1                      '#fc0'
-#    highway_link1:               &highway_link1                 red
-#    highway_casing1:             &highway_casing1               black
-#    highway_tunnel1:             &highway_tunnel1               maroon
-#    highway_tunnel_casing1:      &highway_tunnel_casing1        [0.8, 0.8, 0.7]
-#    highway_link_tunnel_casing1: &highway_link_tunnel_casing1   [0.8, 0.8, 0.7]
-#    ferry1:                      &ferry1                        '#8bb5e4'
-#    major_road1:                 &major_road1                   [1.00, 1.00, 1.00]
-#    major_road1r:                &major_road1r                  green
-#    major_road1b:                &major_road1b                  teal
-#    major_road2:                 &major_road2                   teal
-#    major_road2r:                &major_road2r                  lime
-#    major_road2a:                &major_road2a                  teal
-#    major_road2b:                &major_road2b                  teal
-#    major_road3:                 &major_road3                   teal
-#    major_casing1:               &major_casing1                 black               # same as highway_casing1
-#    major_casing2:               &major_casing2                 grey                # zoomed out
-#    major_tunnel1:               &major_tunnel1                 aqua
-#    major_tunnel_casing1:        &major_tunnel_casing1         [0.8, 0.8, 0.7]
-#    major_route1:                &major_route1                  orange
-#    major_route2:                &major_route2                  orange              # zoomed out
-#    minor_route:                 &minor_route                   purple              # same as major_route
-#    major_road4:                 &major_road4                   [0.60, 0.60, 0.60]
-#    minor_road1:                 &minor_road1                   [0.60, 0.60, 0.60]  # natural earth
-#    minor_road2:                 &minor_road2                   [0.80, 0.80, 0.80]  # natural earth, same as major_road2
-#    minor_road3:                 &minor_road3                   '#ccc'
-#    minor_road4:                 &minor_road4                   '#868686'           # zoomed out
-#    minor_road5:                 &minor_road5                   '#909090'           # zoomed out, again
-#    minor_tunnel1:               &minor_tunnel1                 fuchsia
-#    minor_tunnel_casing1:        &minor_tunnel_casing1          [0.8, 0.8, 0.7]
-#    service_road1:               &service_road1                 white
-#    service_road_casing1:        &service_road_casing1          grey
-#    path1:                       &path1                         '#bcc19e'
-#    path2:                       &path2                         '#c1bc9d'           # zoomed out
-#    path_casing1:                &path_casing1                  '#5d6b5d'
-#    path_bridge_casing1:         &path_bridge_casing1           black
-#    path_bridge_casing2:         &path_bridge_casing2           grey                # zoomed out
-#    path_steps1:                 &path_steps1                   black
-#    
-#    #areas
-#    scene1:     &scene1      '#eee'              # map background, water
-#    water1:     &water1      [0.83, 0.83, 0.83]  # water
-#    earth1:     &earth1      white               # land color
-#    green1:     &green1      [0.50,0.50,0.50]    # park
-#    green2:     &green2      '#949494'           # cemetery
-#    green3:     &green3      '#9a9a9a'           # golf course
-#    green4:     &green4      [0.90,0.90,0.90]    # farm faint
-#    green5:     &green5      [0.75,0.75,0.75]    # farm
-#    green6:     &green6      [0.40,0.40,0.40]    # nature reserve
-#    green7:     &green7      '#aaaaaa'           # forest
-#    orange1:    &orange1     '#aaaaaa'           # stadium
-#    brown1:     &brown1      '#7b7b7b'           # university
-#    brown2:     &brown2      '#aaaaaa'           # school
-#    brown3:     &brown3      '#b8b8b8'           # playground
-#    red1:       &red1        '#a2a2a2'           # hospital
-#    grey1:      &grey1       '#787878'           # pedestrian, retail, airport apron, parking, church
-#    grey2:      &grey2       [0.5, 0.5, 0.5]     # airport runway
-#    grey3:      &grey3       grey                # railway
-#    mystry1:    &mystry1     '#aaaaaa'           # recreation ground (type of park, sometimes around reservoirs)
-#    building1:  &building1   [0.3, 0.3, 0.3]     # building
-#    building2:  &building2   [0.2, 0.2, 0.2]     # building stroke
-#    building_o: &building_o  5                   # building stroke order
-#    
-#    #labels
-#    text_fill:   &text_fill   white              # WHITE
-#    text_stroke: &text_stroke '#444'             # land color
-
-
-textures:
-    pois:
-        url: poi_icons_18@2x.png
-        filtering: mipmap
-        sprites:
-            # define sprites: [x origin, y origin, width, height]
-            airport: [631, 105, 36, 36]
-            aquarium: [630, 530, 36, 36]
-            baseball-field: [632, 1455, 36, 36]
-            basketball-court: [886, 1539, 36, 36]
-            basketball-stadium: [716, 1456, 36, 36]
-            battlefield: [973, 696, 36, 36]
-            beach: [382, 531, 36, 36]
-            beach-resort: [1389, 531, 36, 36]
-            campground: [1220, 533, 36, 36]
-            cemetery: [632, 275, 36, 36]
-            church: [464, 275, 36, 36]
-            city: [296, 695, 36, 36]
-            clinic: [462, 355, 36, 36]
-            college-university: [296, 444, 36, 36]
-            concert-hall: [382, 2052, 36, 36]
-            courthouse: [632, 18, 36, 36]
-            fire-station: [384, 18, 36, 36]
-            football-stadium: [548, 1454, 36, 36]
-            fun-fair: [880, 529, 36, 36]
-            generic: [294, 2137, 36, 36]
-            golf-course: [296, 1457, 36, 36]
-            government-building: [802, 18, 36, 36]
-            grocery-store: [298, 1627, 36, 36]
-            harbor-marina: [1306, 532, 36, 36]
-            historic-site: [888, 18, 36, 36]
-            hockey-field: [718, 1539, 36, 36]
-            hospital: [295, 356, 36, 36]
-            hot-spring: [630, 778, 36, 36]
-            island: [462, 777, 36, 36]
-            landmark: [468, 617, 36, 36]
-            library: [554, 18, 36, 36]
-            light-rail: [298, 102, 36, 36]
-            lighthouse: [384, 617, 36, 36]
-            mall: [380, 862, 36, 36]
-            medical-center: [632, 356, 36, 36]
-            military-base: [972, 18, 36, 36]
-            movie-theatre: [468, 2052, 36, 36]
-            museum: [718, 18, 36, 36]
-            music-venue: [296, 2052, 36, 36]
-            other-outdoors: [966, 614, 36, 36]
-            park: [296, 529, 36, 36]
-            performing-arts: [546, 2051, 36, 36]
-            playground: [470, 531, 36, 36]
-            police: [300, 18, 36, 36]
-            pool: [716, 533, 36, 36]
-            post-office: [468, 18, 36, 36]
-            racetrack: [1134, 529, 36, 36]
-            rest-area: [1473, 194, 36, 36]
-            school: [380, 442, 36, 36]
-            ski-area: [802, 1458, 36, 36]
-            soccer-field: [466, 1539, 36, 36]
-            soccer-stadium: [464, 1454, 36, 36]
-            stadium: [380, 1455, 36, 36]
-            subway: [381, 102, 36, 36]
-            swimming: [296, 1539, 36, 36]
-            theme-park: [798, 529, 36, 36]
-            zoo: [550, 529, 36, 36]
 
 sources:
     osm:
@@ -481,16 +113,10 @@ sources:
         #url:  //localhost:8080//osm/all/{z}/{x}/{y}.topojson
         url:  //vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson?api_key=vector-tiles-HqUVidw
 
-camera:
-    type: isometric
-    axis: [0, .1] # very small building extrusion
-
-lights:
-    light1:
-        type: directional
-        direction: [1, 1, -.9]
-        diffuse: .5
-        ambient: .85
+cameras:
+    perspective:
+        type: isometric
+        vanishing_point: [0, -500]
 
 styles:
     flatlines:
@@ -499,6 +125,7 @@ styles:
     flatpolys:
         base: polygons
         lighting: false # ignore lights
+
     dashedline:
         base: lines
         lighting: false # ignore lights
@@ -536,13 +163,13 @@ styles:
                     float xMargin(vec2 st,float margin){
                         return 1.0-clamp(step(margin*.5,st.x)*step(margin*.5,1.0-st.x),0.,1.);
                     }
-                    
+
                     //  Function from Iñigo Quiles
                     //  https://www.shadertoy.com/view/MsS3Wc
                     vec3 hsb2rgb( in vec3 c ){
                         vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),
-                                                 6.0)-3.0)-1.0, 
-                                         0.0, 
+                                                 6.0)-3.0)-1.0,
+                                         0.0,
                                          1.0 );
                         rgb = rgb*rgb*(3.0-2.0*rgb);
                         return c.z * mix(vec3(1.0), rgb, c.y);
@@ -558,137 +185,30 @@ styles:
                      color = mix(v_color,foreground, chevron(st) - xMargin(st,.25) );
                      color = mix(v_color,foreground, stripes(st) );
                     // color = mix(v_color,foreground, clamp(stripes(st)-xMargin(st,.9),0.,1.) ) ;
-    dots:
-        mix: tools
-        blend: overlay
-        base: polygons
-        texcoords: true
-        shaders:
-            blocks:
-                color: |
-                    vec2 st = TileCoords();
-                    st = brickTile(st,40.0);
-                    float b = circle(st,0.1);
-                    //color = vec4(0.460,0.460,0.460,1.0)*vec4(b);
-                    color *= vec4(b);
-                    
-    dots2:
-        mix: tools
-        base: polygons
-        shaders:
-            blocks:
-                color: |
-                    vec2 st = TileCoords();
-                    st = brickTile(st,100.0);
-                    float b = circle(st,0.2);
-                filter: |
-                    color.rgb = mix(vec3(0.9), vec3(0.8), b);
-                    color.rgb -= grain(gl_FragCoord.xy)*0.1;
-
-    blueprint:
-        base: polygons
-        shaders:
-            blocks:
-                global: |
-                    float getIntensity(vec3 a){ return (a.x+a.y+a.z)/3.0; }
-                    float hash(vec2 p) { return fract(1e4 * sin(17.0 * p.x + p.y * 0.1) * (0.1 + abs(sin(p.y * 13.0 + p.x)))); }
-                    float noise(vec2 x) {
-                        vec2 i = floor(x);
-                        vec2 f = fract(x);
-
-                        float a = hash(i);
-                        float b = hash(i + vec2(1.0, 0.0));
-                        float c = hash(i + vec2(0.0, 1.0));
-                        float d = hash(i + vec2(1.0, 1.0));
-
-                        vec2 u = f * f * (3.0 - 2.0 * f);
-                        return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
-                    }
-                    float fbm( in vec2 p ){
-                        float s = 0.0;
-                        float m = 0.0;
-                        float a = 0.5;
-                        for(int i=0; i<2; i++ ){
-                            s += a * noise(p);
-                            m += a;
-                            a *= 0.5;
-                            p *= 2.0;
-                        }
-                        return s/m;
-                    }
-                    bool grid(vec2 _pos, float _res){
-                        vec2 grid = fract(_pos*_res);
-                        return grid.x < _res || grid.y < _res;
-                    }
-                    vec3 BluePrint(vec2 _pos){
-                        vec2 st = _pos/u_resolution.xy-vec2(.5);
-                        vec3 background = mix(  vec3(0.,0.5,0.8), 
-                                                vec3(0.,0.0,0.3), 
-                                                dot(st,st) + (fbm(_pos*0.6)*0.1) );
-                        if(grid(_pos,0.01)){
-                            background += vec3(0.05);
-                        }
-
-                        if(grid(_pos,0.1)){
-                            background += vec3(0.02);
-                        }
-
-                        return background;
-                    }
-                filter: |
-                    color.rgb += BluePrint(gl_FragCoord.xy);
-    base:
-        base: polygons
-        mix: blueprint
-        lighting: false
-
-    buildings:
-        base: polygons
-        mix: blueprint
-        texcoords: true
-        lighting: false
-        shaders:
-            blocks:
-                position: |
-                    position.z *= max(1.0,0.5+(1.0-(u_map_position.z/20.0))*5.0);
-                color: |
-                    if (dot(v_normal,vec3(0.,0.,1.)) == 0.0){
-                        float lineWidth = 0.003*(u_tile_origin.z/20.0);
-                        color.rgb = 1.0-vec3(step(lineWidth,v_texcoord.x)-step(1.0-lineWidth,v_texcoord.x));
-                    }
-    buildingsLines:
-        base: lines
-        mix: blueprint
-        lighting: false
-        shaders:
-            blocks:
-                width: |
-                    width *= 0.2+min(pow(position.z*0.006,2.),.6);
-                position: |
-                    position.z *= max(1.0,0.5+(1.0-(u_map_position.z/20.0))*5.0);
-                filter: |
-                    color.rgb = mix(BluePrint(gl_FragCoord.xy),
-                                    vec3(1.),
-                                    min(max(0.001,(u_map_position.z-13.))/3.,1.0) );
-    roads:
-        base: lines
-        mix: blueprint
-        lighting: false
-        texcoords: true
-        shaders:
-            blocks:
-                color: |
-                    float lineWidth = 0.1;
-                    float pct = 1.0-(step(lineWidth,v_texcoord.x)-step(1.0-lineWidth,v_texcoord.x));
-                    color.rgb = vec3(0.14+pct*0.1); 
-
-
 
     tools:
         base: polygons
         shaders:
             blocks:
                 global: |
+                    vec2 tile(vec2 _st, float _zoom){
+                      _st *= _zoom;
+                      return fract(_st);
+                    }
+                    
+                    vec2 brickTile(vec2 _st, float _zoom){
+                        _st *= _zoom;
+                        if (fract(_st.y * 0.5) > 0.5){
+                            _st.x += 0.5;
+                        }
+                        return fract(_st);
+                    }
+                    
+                    float circle(vec2 _st, float _radius){
+                      vec2 pos = vec2(0.5)-_st;
+                      return smoothstep(1.0-_radius,1.0-_radius+_radius*0.2,1.-dot(pos,pos)*3.14);
+                    }
+                    
                     // GridTile
                     //=============================
                     varying vec3 v_pos;
@@ -735,63 +255,145 @@ styles:
                         vec2 st = pos/u_resolution.xy-vec2(.5);
                         return dot(st,st)+(fbm(pos*0.6)*0.1);
                     }
-                    vec2 tile(vec2 _st, float _zoom){
-                      _st *= _zoom;
-                      return fract(_st);
+                    // Stripes
+                    //=============================
+                    mat2 rotate2d(float angle){
+                        return mat2(cos(angle),-sin(angle),
+                                    sin(angle),cos(angle));
                     }
-                    
-                    vec2 brickTile(vec2 _st, float _zoom){
-                        _st *= _zoom;
-                        if (fract(_st.y * 0.5) > 0.5){
-                            _st.x += 0.5;
-                        }
-                        return fract(_st);
+                    float stripes(vec2 st){
+                        st = rotate2d(3.14159265358*-0.25 )*st;
+                        //return step(.9,1.0-smoothstep(.5,1.,abs(sin(st.x*3.14159265358))));
+                        return step(.75,1.0-smoothstep(.75,1.,abs(sin(st.x*3.14159265358)))); // more spaced out stripes?
                     }
-                    
-                    float circle(vec2 _st, float _radius){
-                      vec2 pos = vec2(0.5)-_st;
-                      return smoothstep(1.0-_radius,1.0-_radius+_radius*0.2,1.-dot(pos,pos)*3.14);
+
+                    // Stripes
+                    //=============================
+                    float stripes2(vec2 st){
+                        return step(.3,1.0-smoothstep(.5,1.,abs(sin(st.y*3.14159265358))));
                     }
                 position: |
                     // GridTile
                     v_pos = a_position.xyz * 32767.;
-    grid:
-        base: polygons
-        mix: tools
-        shaders:
-            blocks:
-                global: |
                     
-                filter: |
-                    color.rgb += vec3(0.2)*TileGrid();
-                    color.rgb -= grain(gl_FragCoord.xy)*0.5;
-                    
-    ground:
+    water-gradient:
         base: polygons
-        mix: tools
         shaders:
             blocks:
                 filter: |
-                    color.rgb -= grain(gl_FragCoord.xy)*0.5;
-    ground2:
-        base: polygons
-        mix: tools
-        shaders:
-            blocks:
-                filter: |
-                    color.rgb -= grain(gl_FragCoord.xy)*0.2;
-    icons:
-        base: points
-        texture: pois
-        interactive: True
-        
-    pois_text:
-            base: text
-            shaders:
-                blocks:
-                    position: |
-                        position.y -= 19.0* u_meters_per_pixel;
+                    // mix white and green on both axes
+                    color.rgb = mix(vec3(1.0), vec3(0.970), gl_FragCoord.x / u_resolution.x + gl_FragCoord.y / u_resolution.y); 
 
+    wave1:
+        base: polygons
+        mix: tools
+        lighting: false
+        shaders:
+            blocks:
+                filter: |
+                    const float pixel_scale = 695.;
+                    float meter_pixels = u_meters_per_pixel / u_device_pixel_ratio;
+                    vec2 st = gl_FragCoord.xy/pixel_scale;
+                    const float dot_wrap = 1000.;
+                    st += mod(u_map_position.xy / meter_pixels, dot_wrap)/pixel_scale;
+                    
+                    st.y += sin(st.x*30.)*.01;
+
+                    color.rgb = mix(vec3(0.890), vec3(0.870), gl_FragCoord.x / u_resolution.x);
+                    color = mix(color,vec4(0.970,0.970,0.970,1.0),stripes2(st*92.))*1.0;
+
+    wave2:
+        base: polygons
+        mix: tools
+        lighting: false
+        shaders:
+            blocks:
+                filter: |
+                    const float pixel_scale = 695.;
+                    float meter_pixels = u_meters_per_pixel / u_device_pixel_ratio;
+                    vec2 st = gl_FragCoord.xy/pixel_scale;
+                    const float dot_wrap = 1000.;
+                    st += mod(u_map_position.xy / meter_pixels, dot_wrap)/pixel_scale;
+                    
+                    st.y += sin(st.x*30.)*.01;
+
+                    color.rgb = mix(vec3(0.890), vec3(0.760), gl_FragCoord.x / u_resolution.x);
+                    color = mix(color,vec4(0.970,0.970,0.970,1.0),stripes2(st*92.))*1.0;
+
+    coast:
+        base: lines
+        mix: tools
+        lighting: false
+        blend: overlay
+        shaders:
+            blocks:
+                color: |
+                    const float pixel_scale = 695.;
+                    float meter_pixels = u_meters_per_pixel / u_device_pixel_ratio;
+                    vec2 st = gl_FragCoord.xy/pixel_scale;
+                    const float dot_wrap = 1000.;
+                    st += mod(u_map_position.xy / meter_pixels, dot_wrap)/pixel_scale;
+                    
+                    color = mix(vec4(color.rgb, 0.9), vec4(0.), stripes(st*130.))*.8; // transparent stripes
+                    
+                    color.rgb -= grain(gl_FragCoord.xy)*0.5;
+                filter: |
+                    color.rgb += vec3(.2)*TileGrid();
+                    color.rgb -= grain(gl_FragCoord.xy)*0.3;
+                    
+    dots:
+        mix: tools
+        base: polygons
+        shaders:
+            blocks:
+                color: |
+                    vec2 st = TileCoords();
+                    st = tile(st,50.0);
+                    float dot_size = .1;
+                    float b = circle(st, dot_size);
+                    color *= vec4(b);
+                filter: |
+                    color.rgb = mix(COLOR1, COLOR2, b);
+                    
+    park-dots1:
+        mix: dots
+        shaders:
+            defines:
+                    COLOR1: vec3(1.00,1.00,1.00)
+                    COLOR2: vec3(0.500,0.500,0.500)
+
+    park-dots2:
+        mix: dots
+        shaders:
+            defines:
+                    COLOR1: vec3(1.00,1.00,1.00)
+                    COLOR2: vec3(0.650,0.650,0.650)
+
+    park-dots3:
+        mix: dots
+        shaders:
+            defines:
+                    COLOR1: vec3(1.00,1.00,1.00)
+                    COLOR2: vec3(0.800,0.800,0.800)
+
+    buildings_grid:
+        base: polygons
+        texcoords: true
+        shaders:
+            blocks:
+                color: |
+                    vec2 st = v_texcoord.xy;
+                    vec2 f_st = fract(st*8.);
+                    vec2 i_st = floor(st*8.);
+                    // color.rg = f_st;
+                    
+                    vec2 pct = step(vec2(0.09),f_st);;
+                    color.rgb -= mix(vec3(0.0), vec3(0.4),(1.0-(pct.x * pct.y)));
+                    
+                    if ( dot(vec3(0.,0.,1.),normal) == 1.0 ) {
+                        // If it's a roof
+                        color.rgb = vec3(0.988);
+                    }
 
 scene:
     background:
@@ -801,47 +403,75 @@ layers:
     earth:
         data: { source: osm, layer: earth }
         draw:
-            flatpolys:
+            coast:
+                order: 10
+                width: 4px
+                color: [0.761, 0.761, 0.761]
+            polygons:
                 order: 0
-                color: *earth1
-#            lines:
-#                order: 10
-#                width: 1px
-#                color: red
+                color: [1.0,1.0,1.0]
 
-    water:
+    water-early:
         data: { source: osm, layer: water }
         draw:
-            ground:
-                order: -1
+            water-gradient:
+                order: 3
+                color: *water1
+
+    water-fade:
+        data: { source: osm, layer: water }
+        filter: { $zoom: { min: 9, max: 13 } }
+        draw:
+            wave1:
+                order: 3
                 color: *water1
         lakes:
             filter: 
                 all:
-                    - kind: [ocean, water, reservoir]
+                    - kind: [ocean, lake, water, reservoir]
                 any:
                     # limit show smaller landuse areas to higher zooms
                     - { $zoom: { min: 9 },  area: { min: 10000000 } }
                     - { $zoom: { min: 10 }, area: { min: 8000000 } }
+                    - { $zoom: { min: 10 }, area: { min: 8000000 } }
                     - { $zoom: { min: 11 }, area: { min: 2000000 } }
                     - { $zoom: { min: 12 }, area: { min: 500000 } }
+                    - { $zoom: { min: 13 }, area: { min: 100000 } }
+            draw:
+                wave1:
+                    color: *water1
+        other_water:
+            filter: { not: { kind: [ocean, lake, water, reservoir] }, $zoom: { min: 10 }, area: { min: 100 } }
+            draw:
+                wave1:
+                    color: *water1
+
+    water-late:
+        data: { source: osm, layer: water }
+        filter: { $zoom: { min: 13 } }
+        draw:
+            wave2:
+                order: 3
+                color: *water1
+        lakes:
+            filter: 
+                all:
+                    - kind: [ocean, lake, water, reservoir]
+                any:
+                    # limit show smaller landuse areas to higher zooms
                     - { $zoom: { min: 13 }, area: { min: 100000 } }
                     - { $zoom: { min: 14 }, area: { min: 50000 } }
                     - { $zoom: { min: 15 }, area: { min: 20000 } }
                     - { $zoom: { min: 15 }, area: { min: 2000 } }
-                    - { $zoom: { min: 16 } }    
+                    - { $zoom: { min: 16 } }
             draw:
-                ground:
-                    order: 3
+                wave2:
                     color: *water1
         other_water:
-            filter: { not: { kind: [ocean, water, reservoir] }, $zoom: { min: 11 }, area: { min: 100 } }
+            filter: { not: { kind: [ocean, lake, water, reservoir] }, $zoom: { min: 13 }, area: { min: 100 } }
             draw:
-                ground:
-                    order: 3
+                wave2:
                     color: *water1
-
-
 
     roads:
         data: { source: osm, layer: roads }
@@ -869,19 +499,20 @@ layers:
                 flatlines:
                     # put highways on top of all other roads
                     order: 8
-                    color: *highway1
-                    width: [[9, 2px], [14, 3px], [16, 4px], [17, 10m]]
+                    color: black
+                    width: [[5, 1px], [7, 1.25px], [9, 1.5px], [14, 1.5px], [16, 4px], [17, 10m]]
                     outline:
                         color: *highway_casing1
-                        width: [[9, 0], [12, 1px], [16, 2px]]
+                        width: [[9, 0px], [10, 0px], [12, 1px], [16, 2px]]
             major_road:
                 filter: { type: ['Secondary Highway','Road'] }
                 draw:
                     flatlines:
-                        color: [[13, *major_road2], [17, *major_road1]]
-                        width: [[9, 1px], [11, 1.5px], [13, 2.5px], [16, 2.5px], [19, 8m]]
+                        color: [[5, [0.5,0.5,0.5]], [8, [0.4,0.4,0.4]], [13, [0.4,0.4,0.4]], [17, *major_road1]]
+                        #color: red
+                        width: [[5, 0.25px], [7, 0.5px], [7, 0.75px], [9, 1px], [10, 9px], [11, 9px], [13, 1px], [16, 2.5px], [19, 8m]]
                         outline:
-                            width: [[8, 0.0px], [9, 0.5px], [11, .5px], [16, .75px]]
+                            width: [[8, 0.0px], [9, 0.0px], [11, .5px], [16, .75px]]
             minor_road:
                 filter: { type: 'Unknown' }
                 draw:
@@ -906,11 +537,11 @@ layers:
                 flatlines:
                     # put highways on top of all other roads
                     order: 8
-                    color: *highway1
-                    width: [[8, 2px], [9, 2.5px], [14, 4.0px], [15, 6.0px], [16, 6.5px], [17, 20m]]
+                    color: [[8, [0.0,0.0,0.0]], [9, [0.0,0.0,0.0]], [10, [0.0,0.0,0.0]], [11, [0.0,0.0,0.0]], [13, [0.0,0.0,0.0]], [14, [0.0,0.0,0.0]], [15, [0.0,0.0,0.0]], [16, [0.0,0.0,0.0]], [17, [0.0,0.0,0.0]]]
+                    width: [[8, 1px], [10, 1.15px], [11, 1px], [12, 1px], [14, 1.75px], [15, 3px], [16, 4px], [17, 4px]]
                     outline:
                         color: *highway_casing1
-                        width: [[9, 0.5px], [12, 1px], [16, 2px], [18, 6px]]
+                        width: [[9, 0px], [10, 0px], [11, 0px], [12, 0px], [13, 0px], [14, 0px], [15, 0px], [16, 0px], [17, 0px], [18, 0px]]
             not_link:
                 filter: { not: { is_link: yes }, $zoom: {max: 15} }
                 draw:
@@ -923,11 +554,11 @@ layers:
                 filter: { is_link: yes } # on- and off-ramps, etc
                 draw:
                     flatlines:
-                        color: *highway_link1
-                        width: [[9, 1px], [14, 2.5px], [16, 4px], [18, 9m]]
+                        color: [[9, [0.0,0.0,0.0]], [11, [0.0,0.0,0.0]], [12, [0.0,0.0,0.0]], [14, [0.3,0.3,0.3]], [15, [0.1,0.1,0.1]], [16, [0.1,0.1,0.1]], [17, [0.0,0.0,0.0]]]
+                        width: [[9, 0px], [11, 0.15px], [12, 0.5px], [13, 0.75px], [14, 0.75px], [15, 1.5px], [16, 1.75px], [17, 1.75px], [18, 1.75px]]
                         outline:
                             color: *highway_casing1
-                            width: [[10, 1px], [14, 1px], [18, 1.5px]]
+                            width: [[9, 0px], [10, 0px], [12, 0px], [13, 0px], [14, 0px], [15, 0px], [17, 0px], [18, 0px]]
                 early_link:
                     filter: { $zoom: {min: 13, max: 15} }
                     draw:
@@ -946,10 +577,11 @@ layers:
                 draw:
                     flatlines:
                         order: 4
-                        color: *highway_tunnel1
+                        color: [[13,*highway_tunnel1], [14,*highway_tunnel1], [15,[0.8,0.8,0.8]], [16,[0.85,0.85,0.85]]]
                         outline:
                             color: *highway_tunnel_casing1
-                            
+                            width: 0px
+
             labels-highway-early:
                 filter: { $zoom: { min: 7, max: 13 } }
                 draw:
@@ -958,7 +590,7 @@ layers:
                         text_source: ref
                         font:
                             fill: *text_fill
-                            typeface: 500 12px Helvetica
+                            typeface: 500 9px Helvetica
                             stroke: { color: *text_stroke, width: 4 }
             labels-highway-late:
                 filter: { $zoom: { min: 13, max: 14 } }
@@ -966,21 +598,21 @@ layers:
                     text:
                         visible: *text_visible_highway
                         #text_source: ref
-                        text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name } }
+                        text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name; } }
                         font:
                             fill: *text_fill
-                            typeface: 500 13px Helvetica
+                            typeface: 500 10px Helvetica
                             stroke: { color: *text_stroke, width: 4 }
-            later:
+            labels-highway-late2:
                 filter: { $zoom: { min: 14, max: 15 } }
                 draw:
                     text:
                         visible: *text_visible_highway
                         font:
                             fill: *text_fill
-                            typeface: 500 14px Helvetica
+                            typeface: 500 10px Helvetica
                             stroke: { color: *text_stroke, width: 4 }
-            later2:
+            labels-highway-late3:
                 filter: { $zoom: { min: 15, max: 18 } }
                 draw:
                     text:
@@ -995,8 +627,9 @@ layers:
                     text:
                         visible: *text_visible_highway
                         font:
-                            fill: *text_stroke
+                            fill: *text_fill
                             typeface: 500 18px Helvetica
+                            stroke: { color: *text_stroke, width: 4 }
 
         major_road:
             filter: { kind: major_road }
@@ -1004,26 +637,26 @@ layers:
             draw:
                 flatlines:
                     color: [[8, *major_road4], [13, major_road2], [17, *major_road1]]
-                    width: [[13, 0px], [14, 2px], [16, 2.5px], [19, 8m]]
+                    width: [[13, 1px], [14, 1px], [16, 2.5px], [19, 8m]]
                     outline:
                         width: [[12, 0px], [13, .5px], [15, 1px]]
             trunk_primary:
                 filter: { highway: [trunk, primary] }
                 draw:
                     flatlines:
-                        color: [[8, *major_road3], [9, *major_road2b], [14, *major_road2], [15, *major_road1b], [17, *major_road1]]
-                        width: [[9, 1.0px], [11, 1.0px], [13, 2.5px], [14, 4.5px], [15, 5.5px], [16, 7.0px], [19, 14m]]
+                        color: [[8, [0.8,0.8,0.8]], [10, [0.8,0.8,0.8]], [12, [0.5,0.5,0.5]], [13, [0.4,0.4,0.4]], [14, [0.3,0.3,0.3]], [15, [0.1,0.1,0.1]], [16, [0.0,0.0,0.0]], [17, [0.0,0.0,0.0]]]
+                        width: [[9, 0.5px], [11, 0.5px], [12, 0.75px], [13, 0.75px], [14, 1px], [15, 1.25px], [16, 3px], [17, 3px], [18, 3px]]
                         outline:
-                            width: [[9, 0.5px], [11, .75px], [12, 1px], [14, 1.5px], [16, 2.5px], [18, 4.5px]]
+                            width: [[9, 0.0px], [11, 0px], [12, 0px], [13, 0px], [14, 0px], [15, 0px], [16, 0px], [17, 0px], [18, 0px]]
                 routes:
                     filter: { ref: true }
                     draw:
                         flatlines:
-                            color: [[8,*major_route2],[10,*major_route1]]
-                            width: [[9, 1.5px], [11, 2.0px], [14, 3.5px], [15, 4.5px], [16, 6.0px], [17, 12m]]
+                            color: [[8, [0.5,0.5,0.5]], [11, [0.65,0.65,0.65]], [12, [0.2,0.2,0.2]], [13, [0.4,0.4,0.4]], [14, [0.0,0.0,0.0]], [15, [0.0,0.0,0.0]], [16, [0.0,0.0,0.0]], [17, [0.0,0.0,0.0]]]
+                            width: [[9, 0.5px], [10, 0.65px], [11, 0.65px], [12, 0.65px], [13, 0.65px], [14, 1.25px], [15, 1.25px], [16, 3px], [17, 3px], [18, 3px]]
                             outline:
-                                color: *major_casing1
-                                width: [[9, 0.5px], [11, 0.75px], [12, 1px], [16, 2px], [18, 4.5px]]
+                                color: [[8,*major_casing1], [16,[0.0,0.0,0.0]]]
+                                width: [[9, 0.0px], [11, 0px], [12, 0px], [14, 0px], [15, 0px], [16, 0px], [17, 0px], [18, 0px]]
                     tunnel:
                         filter: {is_tunnel: yes, $zoom: {min: 13} }
                         draw:
@@ -1041,35 +674,33 @@ layers:
                                 # but give them all the same outline
                                 outline:
                                     order: 23 # 15 is the starting aboveground level, plus 8
-#                labels-trunk_primary-early2:
-#                    filter: 
-#                        all:
-#                            - $zoom: { min: 9, max: 10 }
-#                            - function() { if( feature.ref.startsWith('I') ||  feature.ref.startsWith('US') ) { return true } else { return false } }
-#                    draw:
-#                        text:
-#                            visible: *text_visible_trunk_primary
-#                            text_source: ref
-#                            font:
-#                                fill: white
-#                                typeface: 500 12px Helvetica
-                labels-trunk_primary-early:
-                    filter: { $zoom: { min: 10, max: 15 } }
+
+                labels-trunk_primary-early1:
+                    filter: { $zoom: { min: 11, max: 13 } }
                     draw:
                         text:
                             visible: *text_visible_trunk_primary
-                            text_source: ref
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
                             font:
-                                fill: *text_fill
-                                typeface: 500 13px Helvetica
+                                fill: [0.35,0.35,0.35]
+                                typeface: 500 8px Helvetica
+                                stroke: { color: *text_stroke, width: 3 }
+                labels-trunk_primary-early2:
+                    filter: { $zoom: { min: 13, max: 15 } }
+                    draw:
+                        text:
+                            visible: *text_visible_trunk_primary
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
+                            font:
+                                fill: [0.35,0.35,0.35]
+                                typeface: 500 10px Helvetica
                                 stroke: { color: *text_stroke, width: 4 }
                 labels-trunk_primary-late:
                     filter: { $zoom: { min: 15, max: 18 } }
                     draw:
                         text:
                             visible: *text_visible_trunk_primary
-                            #text_source: ref
-                            text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name } }
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
                             font:
                                 fill: *text_fill
                                 typeface: 500 14px Helvetica
@@ -1079,21 +710,20 @@ layers:
                     draw:
                         text:
                             visible: *text_visible_trunk_primary
-                            #text_source: ref
-                            text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name } }
+                            text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name; } }
                             font:
-                                fill: *text_stroke
+                                fill: *text_fill
                                 typeface: 500 18px Helvetica
-
+                                stroke: { color: *text_stroke, width: 4 }
             link:
                 filter: { is_link: yes } # on- and off-ramps, etc
                 draw:
                     flatlines:
-                        color: [[8, *major_road3], [9, *major_road2b], [14, *major_road2], [15, *major_road1b], [17, *major_road1]]
-                        width: [[10, 1px], [14, 3px], [16, 4.5px], [18, 10m]]
+                        color: [[10, [0.4,0.4,0.4]], [14, [0.75,0.75,0.75]], [15, [0.89, 0.89, 0.89]], [16, [0.1,0.1,0.1]], [17, [0.0,0.0,0.0]]]
+                        width: [[10, 0.5px], [14, 1.5px], [15, 1px], [16, 1.75px], [17, 1.5px], [18, 1.5px]]
                         outline:
                             color: *major_casing1
-                            width: [[10, 1px], [14, 1px], [18, 1.5px]]
+                            width: [[10, 0px], [14, 0px], [15, 0px], [16, 0px], [17, 0px], [18, 0px]]
             tunnel:
                 filter: {is_tunnel: yes, $zoom: {min: 13} }
                 draw:
@@ -1106,15 +736,18 @@ layers:
                 filter: { highway: secondary }
                 draw:
                     flatlines:
-                        color: [[13,*major_road2b], [14,*major_road2a], [15,*major_road1b], [17,*major_road1]]
-                        width: [[11, 1.0px], [12, 1.0px], [13, 2.0px], [14, 3.5px], [15, 4.5px], [16, 7.0px], [19, 16m]]
+                        color: [[10, [0.75,0.75,0.75]], [11, [0.8,0.8,0.8]], [12, [0.6,0.6,0.6]], [13, [0.4,0.4,0.4]], [14, [0.35,0.35,0.35]], [15, [0.35,0.35,0.35]], [17, [0.0,0.0,0.0]]]
+                        width: [[10, 0.5px], [12, 0.5px], [13, 0.65px], [14, 1px], [15, 1.25px], [16, 2px], [17, 2px], [18, 2px]]
                         outline:
-                            width: [[11, 0px], [12, .75px], [13, 1.0px], [14, 1.75px], [15, 2.0px], [16, 3.0px], [18, 4.0px]]
+                            width: [[11, 0px], [12, 0px], [13, 0px], [14, 0px], [15, 0px], [16, 0px], [17, 0px], [18, 0px]]
                 routes:
                     filter: { ref: true, $zoom: { min: 12} }
                     draw:
                         flatlines:
-                            color: *minor_route
+                            color: [[12, [0.6,0.6,0.6]], [13, [0.4,0.4,0.4]], [14, [0.35,0.35,0.35]], [15, [0.35,0.35,0.35]], [16, [0.35,0.35,0.35]], [17, [0.0,0.0,0.0]]]
+                        width: [[11, 0.5px], [12, 0.5px], [13, 0.65px], [14, 1px], [15, 1.25px], [16, 2px], [17, 2px], [19, 16m]]
+                        outline:
+                            width: [[11, 0px], [12, 0px], [13, 0px], [14, 0px], [15, 0px], [16, 0px], [17, 0px], [18, 1px]]
                     tunnel:
                         filter: {is_tunnel: yes, $zoom: {min: 13} }
                         draw:
@@ -1128,45 +761,59 @@ layers:
                         draw:
                             text:
                                 visible: *text_visible_secondary
-                                text_source: ref
+                                text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
                                 font:
                                     fill: *text_fill
-                                    typeface: 500 12px Helvetica
+                                    typeface: 500 13px Helvetica
                                     stroke: { color: *text_stroke, width: 4 }
                 labels-secondary:
-                    filter: { $zoom: { min: 14, max: 18 } }
+                    filter: { $zoom: { min: 13, max: 15 } }
                     draw:
                         text:
                             visible: *text_visible_secondary
-                            #text_source: ref
-                            text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name } }
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
+                            font:
+                                fill: [0.35,0.35,0.35]
+                                typeface: 500 10px Helvetica
+                                stroke: { color: *text_stroke, width: 4 }
+                labels-secondary2:
+                    filter: { $zoom: { min: 15, max: 18 } }
+                    draw:
+                        text:
+                            visible: *text_visible_secondary
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
                             font:
                                 fill: *text_fill
-                                typeface: 500 12px Helvetica
+                                typeface: 500 14px Helvetica
                                 stroke: { color: *text_stroke, width: 4 }
-                labels-secondary:
+                labels-secondary3:
                     filter: { $zoom: { min: 18 } }
                     draw:
                         text:
                             visible: *text_visible_secondary
                             #text_source: ref
-                            text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name } }
+                            text_source: function() { if( feature.ref && feature.name ) { return feature.ref + " " + feature.name; } else { return feature.name; } }
                             font:
-                                fill: *text_stroke
-                                typeface: 500 18px Helvetica
+                                fill: *text_fill
+                                typeface: 500 16px Helvetica
+                                stroke: { color: *text_stroke, width: 4 }
             tertiary:
                 filter: { highway: [tertiary, tertiary_link] }
                 draw:
                     flatlines:
-                        color: [[13,*major_road2b], [14,*major_road2a], [15,*major_road1b], [17,*major_road1]]
-                        width: [[11, 0.5px], [12, .75px], [14, 2.5px], [15, 4.0px], [16, 4.5px], [19, 10m]]
+                        color: [[11, [0.885,0.885,0.885]], [13, [0.6,0.6,0.6]], [14, [0.75,0.75,0.75]], [15, [0.6,0.6,0.6]], [16, [0.3,0.3,0.3]], [17, [0.0,0.0,0.0]]]
+                        width: [[11, 0.5px], [12, .75px], [13, 0.65px], [14, 1px], [15, 1px], [16, 2px], [17, 2px], [18, 2px]]
                         outline:
-                            width: [[12, 0px], [13, 0.5px], [14, 1.0px], [15, 1.5px], [16, 2.0px], [18, 3.5px]]
+                            color: [[15, [0.7,0.7,0.7]], [16, [0.0,0.0,0.0]], [17, [0.0,0.0,0.0]]]
+                            width: [[12, 0px], [13, 0px], [14, 0px], [15, 0px], [16, 0px], [17, 0px]]
                 routes:
                     filter: { ref: true, $zoom: { min: 12} }
                     draw:
                         flatlines:
-                            color: *minor_route
+                            color: [[11, [0.885,0.885,0.885]], [13, [0.8,0.8,0.8]], [14, [0.75,0.75,0.75]], [15, [0.6,0.6,0.6]], [17, [0.0,0.0,0.0]]]
+                        width: [[11, 0.5px], [12, .75px], [13, 1px], [14, 1px], [15, 1px], [16, 2px], [17, 2px], [18, 2px]]
+                        outline:
+                            width: [[12, 0px], [13, 0px], [14, 0px], [15, 0px], [16, 0px], [18, 0px]]
                     tunnel:
                         filter: {is_tunnel: yes, $zoom: {min: 13} }
                         draw:
@@ -1179,39 +826,52 @@ layers:
                     filter: { is_link: yes } # on- and off-ramps, etc
                     draw:
                         flatlines:
-                            color: *major_road1
-                            width: [[11, 0.0px], [12, .5px], [14, 1.5px], [16, 2.0px], [19, 7m]]
+                            color: [[14, [0.75,0.75,0.75]], [15, [0.6, 0.6, 0.6]], [16, [0.3,0.3,0.3]], [17, [0.0,0.0,0.0]]]
+                            width: [[11, 0.0px], [12, 0.15px], [14, 0.15px], [15, 0.75px], [16, 1.25px], [17, 1.25px], [18, 1.25px]]
                             outline:
                                 color: [[12,*major_casing2],[13,*major_casing1]]
-                                width: [[12, 0px], [14, .25px], [16, 1.0px], [18, 4.0px]]
+                                width: [[12, 0px], [14, 0px], [16, 0px], [17, 0px], [18, 0px]]
                 labels-tertiary:
-                    filter: { $zoom: { min: 14, max: 18 } }
+                    filter: { $zoom: { min: 14, max: 15 } }
                     draw:
                         text:
                             visible: *text_visible_tertiary
-                            text_source: name
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
                             font:
                                 fill: *text_fill
-                                typeface: 500 12px Helvetica
+                                typeface: 500 10px Helvetica
                                 stroke: { color: *text_stroke, width: 4 }
-                labels-tertiary:
+                labels-tertiary2:
+                    filter: { $zoom: { min: 15, max: 18 } }
+                    draw:
+                        text:
+                            visible: *text_visible_tertiary
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
+                            font:
+                                fill: *text_fill
+                                typeface: 500 14px Helvetica
+                                stroke: { color: *text_stroke, width: 4 }
+                labels-tertiary3:
                     filter: { $zoom: { min: 18 } }
                     draw:
                         text:
                             visible: *text_visible_tertiary
-                            text_source: name
+                            text_source: function() { if( feature.ref && feature.name ) { if( feature.ref.length < 6 ) { return feature.ref + " " + feature.name; } else { return feature.name; } } else { return feature.name; } }
                             font:
-                                fill: *text_stroke
+                                fill: *text_fill
                                 typeface: 500 15px Helvetica
+                                stroke: { color: *text_stroke, width: 4 }
+
         minor_road:
             filter: { kind: minor_road, not: { highway: service } }
             draw:
                 flatlines:
                     # order: 3
-                    color: [[12, *minor_road5], [13, *minor_road4], [14, *minor_road3]]
-                    width: [[12, 0.75px], [13, 1.5px], [14, 1.5px], [15, 2.5px], [16, 8m]]
+                    color: [[12, [0.885,0.885,0.885]], [13, [0.8,0.8,0.8]], [14, [0.75,0.75,0.75]], [15, [0.6,0.6,0.6]], [16, [0.3,0.3,0.3]], [17, [0.0,0.0,0.0]]]
+                    width: [[12, 0.35px], [13, 0.5px], [14, 1px], [15, 1px], [16, 2px], [18, 2px]]
                     outline:
-                        width: [[12, 0.0px], [13, 0.25px], [14, 0.5px], [17, 1.0px]]
+                        color: [[15, [0.7,0.7,0.7]], [16, [0.0,0.0,0.0]]]
+                        width: [[12, 0.0px], [13, 0px], [14, 0px], [15, 0px], [16, 0px], [18, 0px]]
             tunnel:
                 filter: {is_tunnel: yes, $zoom: {min: 13} }
                 draw:
@@ -1220,9 +880,8 @@ layers:
                         color: *minor_tunnel1
                         outline:
                             color: *minor_tunnel_casing1
-                        
             labels-minor_road:
-                filter: { $zoom: { min: 16, max: 19 } }
+                filter: { $zoom: { min: 16, max: 18 } }
                 draw:
                     text:
                         visible: *text_visible_minor_road
@@ -1232,26 +891,28 @@ layers:
                             typeface: 500 12px Helvetica
                             stroke: { color: *text_stroke, width: 4 }
             labels-minor_road2:
-                filter: { $zoom: { min: 19 } }
+                filter: { $zoom: { min: 18 } }
                 draw:
                     text:
                         visible: *text_visible_minor_road
                         text_source: name
                         font:
-                            fill: *text_stroke
+                            fill: *text_fill
                             typeface: 500 15px Helvetica
+                            stroke: { color: *text_stroke, width: 4 }
+
         service_road:
             filter: { kind: minor_road, highway: service }
             draw:
                 flatlines:
                     # order: 3
-                    color: *service_road1
-                    width: [[15, 1.5px], [16, 2.0px], [18, 6m]]
+                    color: [[14, [0.75,0.75,0.75]], [15, [0.6, 0.6, 0.6]], [16, [0.3,0.3,0.3]], [18, [0.3,0.3,0.3]]]
+                    width: [[14, 0.15px], [15, 0.75px], [16, 1.25px], [17, 1.25px], [18, 1.25px]]
                     outline:
-                        color: *service_road_casing1
-                        width: [[15, 0.5px], [17, 1.0px]]
+                        color: [[15, [0.7,0.7,0.7]], [16, [0.7,0.7,0.7]], [17, [0.0,0.0,0.0]]]
+                        width: [[14, 0px], [15, 0px], [16, 0px], [17, 0px], [18, 0px]]
             labels-service_road:
-                filter: { $zoom: { min: 17 } }
+                filter: { $zoom: { min: 17, min: 18 } }
                 draw:
                     text:
                         visible: *text_visible_service_road
@@ -1260,24 +921,35 @@ layers:
                             fill: *text_fill
                             typeface: 500 12px Helvetica
                             stroke: { color: *text_stroke, width: 4 }
+            labels-service_road2:
+                filter: { $zoom: { min: 18 } }
+                draw:
+                    text:
+                        visible: *text_visible_service_road
+                        text_source: name
+                        font:
+                            fill: *text_fill
+                            typeface: 500 12px Helvetica
+                            stroke: { color: *text_stroke, width: 4 }
+
         path:
-            filter: { kind: path, not: { highway: steps } }
+            filter: { kind: path }
             draw:
                 flatlines:
-                    color: [[15,*path2],[16,*path1]]
-                    order: 6
-                    width: [[15, 1.5], [17, 3m]]
+                    color: [[15, [0.6,0.6,0.6]], [16, [0.6,0.6,0.6]], [18, [0.6,0.6,0.6]]]
+                    width: [[15, 0.5px], [16, 0.5px], [17, 0.5px], [18, 0.5px]]
                     outline:
-                        color: *path_casing1
-                        width: [[15, 0.0], [18, .1]]
+                        color: [[15, *path_casing1], [14, [0.6,0.6,0.6]]] 
+                        width: [[14, 0px], [15, 0px], [16, 0px], [18, 0px]]
+
             bridge:
                 filter: {is_bridge: yes }
                 draw:
                     flatlines:
-                        width: [[15, 3.5], [17, 3m]]
+                        width: [[15, 0.5px], [16, 0.5px], [17, 0.5px]]
                         outline:
                             color: [[15,*path_bridge_casing2],[16,*path_bridge_casing1]]
-                            width: [[15, 0.5px], [16, 1.0px], [18, 2px]]
+                            width: [[15, 0px], [16, 0px], [17, 0px], [18, 1px]]
             labels-path:
                 filter: { $zoom: { min: 17 } }
                 draw:
@@ -1294,10 +966,10 @@ layers:
                 dashedline:
                     order: 23
                     color: *earth1
-                    width: [[15, 0.1], [17, 0.1]]
+                    width: [[15, 0.5], [16, 0.75px], [17, 1px], [18, 2px]]
                     outline:
                         color: *path_steps1
-                        width: [[15, 1.5], [18, 3m]]
+                        width: [[15, 0], [16, 0], [17, 0], [18, 0]]
             labels-steps:
                 filter: { $zoom: { min: 17 } }
                 draw:
@@ -1308,6 +980,7 @@ layers:
                             fill: *text_fill
                             typeface: 500 12px Helvetica
                             stroke: { color: *text_stroke, width: 4 }
+
         z-order:
             #filter: { $zoom: {min: 12} }
             draw:
@@ -1324,61 +997,45 @@ layers:
                     flatlines:
                         outline:
                             # except bridges and tunnels, their outlines should also self-sort
-                            order: function() { return 6 + feature.sort_key; }
+                            order: function() { return 6 + feature.sort_key;
 
-#    road_labels:
-#        data: { source: osm, layer: roads }
-#        filter: { railway: false, not: { kind: rail }, $zoom: { min: 10 } }
-#        
+    boundaries:
+        data: { source: osm, layer: boundaries }
+        # country subdivisions (states, provinces)
 #        draw:
-#            text:
-#                text_source: sort_key
-#                font: 
-#                    typeface: 500 10pt Helvetica
-#                    fill: white
-#                    stroke: { color: black, width: 4}
-
-
-    # buildings are the only layer that gets lighting
-    buildings:
-        data: { source: osm, layer: buildings }
-        filter: 
-            any:
-                # limit show smaller landuse areas to higher zooms
-                - { $zoom: { min: 12 }, area: { min: 200000 } }
-                - { $zoom: { min: 13 }, area: { min: 100000 } }
-                - { $zoom: { min: 14 }, area: { min: 40000 } }
-                - { $zoom: { min: 15 }, area: { min: 5000 } }
-                - { $zoom: { min: 16 }, area: { min: 1000 } }
-                - { $zoom: { min: 17 } }
-        draw:
-            #filter: { not: { location: underground } }
-            polygons:
-                order: [[0,5],[17,9]]
-                color: *building1
-                # under z15, only extrude buildings taller than 20m
-                extrude: false
-            baseline:
-                style: lines
-                order: *building_o
-                width: [[12, 0.5px], [15, 0.75px], [16, 1.0px], [17, 1.5x], [19, 0.5m]]
-                color: *building2
-#            big-uns:
-#                filter: { $zoom: { min: 17 }, area: { min: 40000 } }
-#                style: lines
-#                order: 5
-#                width: [[12, 1.0px], [16, 1.5px], [17, 1.75x], [18, 2.0x], [19, 1.5m]]
-#                color: *building2
-
-
-
+#            flatlines:
+#                order: 6
+#                color: red
+#                width: [[9, 1px], [14, 2px], [16, 3px], [17, 8m]]
+        country:
+            filter: 
+                any:
+                    - type: country
+                    - kind: nation
+            draw:
+                flatlines:
+                    interactive: true
+                    order: 8
+                    color: *country_boundary
+                    width: [[0, 0.5px], [9, 2.5px], [14, 3.5px], [16, 4.5px], [17, 14m]]
+        regions:
+            filter: 
+                any:
+                    - type: state
+                    # territorial here is probably a hack
+                    - kind: [state, departement, region, provincial, territorial]
+            draw:
+                flatlines:
+                    interactive: true
+                    order: 7
+                    color: *region_boundary
+                    width: [[0, 0.5px], [9, 3.5px], [14, 5.5px], [16, 6.5px], [17, 16m]]
 
     continent:
         data: { source: osm, layer: places }
         filter: { name: true, kind: [continent], $zoom: {max: 5} }
         draw:
             text:
-                visible: *text_visible_continent
                 text_source: function() { return feature.name.toUpperCase(); }
                 font:
                     typeface: italic 14px Helvetica
@@ -1390,19 +1047,17 @@ layers:
         filter: { name: true, kind: [state], $zoom: {min: 5} }
         draw:
             text:
-                visible: *text_visible_admin
                 text_source: function() { return feature.name.toUpperCase(); }
                 font:
                     typeface: 800 14px Helvetica
                     fill: *text_fill
                     stroke: { color: *text_stroke, width: 4 }
-                    
+
     populated-places:
         data: { source: osm, layer: places }
         filter: { name: true, not: { kind: [county, state, island] }, $zoom: {min: 6} }
         draw:
             text:
-                visible: *text_visible_populated_places
                 font:
                     typeface: 800 14px Helvetica
                     fill: *text_fill
@@ -1411,162 +1066,6 @@ layers:
         minor-places:
             filter: { kind: [hamlet, village, town, neighbourhood, suburb, quarter], $zoom: { max: 15 } }
             visible: false
-
-
-    landuse_labels:
-        data: { source: osm, layer: landuse_labels }
-        visible: *label_visible_landuse
-        filter: 
-            name: true
-            not: { kind: [farm] }
-            any:
-                # show labels for smaller landuse areas at higher zooms
-                - { $zoom: { min: 9 },  area: { min: 100000000 } }
-                - { $zoom: { min: 10 }, area: { min: 100000000 } }
-                - { $zoom: { min: 11 }, area: { min: 25000000 } }
-                - { $zoom: { min: 12 }, area: { min: 5000000 } }
-                - { $zoom: { min: 13 }, area: { min: 2000000 } }
-                - { $zoom: { min: 14 }, area: { min: 500000 } }
-                - { $zoom: { min: 15 }, area: { min: 100000 } }
-                - { $zoom: { min: 15 }, area: { min: 50000 } }
-                - { $zoom: { min: 16 }, area: { min: 20000 } }
-                - { $zoom: { min: 18 } }
-        draw:
-            icons:
-                interactive: true
-                size: [[13, 12px], [16, 18px]]
-
-        # add generic icon at high zoom
-        generic-labels:
-            #filter: { $zoom: { min: 18 } }
-            draw: 
-                pois_text:
-                    #text_source: function() { return if( feature.name.lenth > 15) { return feature.name.substring(0,20); } else { return feature.name; } }
-                    visible: *text_visible_landuse
-                    interactive: true
-                    font:
-                        fill: '#666'
-                        typeface: italic 12px Helvetica
-                        stroke: { color: white, width: 4 }
-                        
-         # examples of different icons mapped to feature properties
-        icons:
-            visible: *icon_visible_landuse
-            airport:
-                filter: { kind: [airport, aerodrome] }
-                draw:   { icons: { sprite: airport } }
-            beach:
-                filter: { kind: [beach] }
-                draw:   { icons: { sprite: beach } }
-            cemetery:
-                filter: { kind: [grave_yard, cemetery] }
-                draw:   { icons: { sprite: cemetery } }
-            golf-course:
-                filter: { kind: [golf_course, golf-course] }
-                draw:   { icons: { sprite: golf-course } }
-            hospital:
-                filter: { kind: [hospital] }
-                draw:   { icons: { sprite: hospital } }
-            park:
-                filter: { kind: [park] }
-                draw:   { icons: { sprite: park } }
-            playground:
-                filter: { kind: [playground] }
-                draw:   { icons: { sprite: playground } }
-            mall:
-                filter: { kind: [mall] }
-                draw:   { icons: { sprite: mall } }
-            military-base:
-                filter: { kind: [military_base, military-base] }
-                draw:   { icons: { sprite: military-base } }
-            museum:
-                filter: { kind: [museum, observatory] }
-                draw:   { icons: { sprite: museum } }
-            school:
-                filter: { kind: [school, kindergarten] }
-                draw:   { icons: { sprite: school } }
-            soccer-stadium:
-                filter: { kind: [soccer-stadium] }
-                draw:   { icons: { sprite: soccer-stadium } }
-            stadium:
-                filter: { kind: [stadium] }
-                draw:   { icons: { sprite: stadium } }
-            theme-park:
-                filter: { kind: [theme_park, theme-park, miniature_golf] }
-                draw:   { icons: { sprite: theme-park } }
-            college-university:
-                filter: { kind: [university, college, college-university] }
-                draw:   { icons: { sprite: college-university } }
-            zoo:
-                filter: { kind: [zoo] }
-
-
-    poi_icons:
-        data: { source: osm, layer: pois }
-        visible: *label_visible_poi
-        filter: { kind: [airport, aerodrome, beach, grave_yard, cemetery, golf_course, hospital, park, playground, mall, military_base, museum, observatory, school, kindergarten, stadium, theme_park, miniature_golf, university, college, zoo], $zoom: { min: 16 } }
-        draw:
-            icons:
-                size: [[13, 12px], [16, 18px]]
-                interactive: true
-                pois_text:
-                    visible: *text_visible_poi
-                    font:
-                        fill: '#666'
-                        typeface: 100 12px Helvetica
-                        stroke: { color: white, width: 4 }
-                        
-        # examples of different icons mapped to feature properties
-        icons:
-            visible: *icon_visible_poi
-            airport:
-                filter: { kind: [airport, aerodrome] }
-                draw:   { icons: { sprite: airport } }
-            beach:
-                filter: { kind: [beach] }
-                draw:   { icons: { sprite: beach } }
-            cemetery:
-                filter: { kind: [grave_yard, cemetery] }
-                draw:   { icons: { sprite: cemetery } }
-            golf-course:
-                filter: { kind: [golf_course, golf-course] }
-                draw:   { icons: { sprite: golf-course } }
-            hospital:
-                filter: { kind: [hospital] }
-                draw:   { icons: { sprite: hospital } }
-            park:
-                filter: { kind: [park] }
-                draw:   { icons: { sprite: park } }
-            playground:
-                filter: { kind: [playground] }
-                draw:   { icons: { sprite: playground } }
-            mall:
-                filter: { kind: [mall] }
-                draw:   { icons: { sprite: mall } }
-            military-base:
-                filter: { kind: [military_base, military-base] }
-                draw:   { icons: { sprite: military-base } }
-            museum:
-                filter: { kind: [museum, observatory] }
-                draw:   { icons: { sprite: museum } }
-            school:
-                filter: { kind: [school, kindergarten] }
-                draw:   { icons: { sprite: school } }
-            soccer-stadium:
-                filter: { kind: [soccer-stadium] }
-                draw:   { icons: { sprite: soccer-stadium } }
-            stadium:
-                filter: { kind: [stadium] }
-                draw:   { icons: { sprite: stadium } }
-            theme-park:
-                filter: { kind: [theme_park, theme-park, miniature_golf] }
-                draw:   { icons: { sprite: theme-park } }
-            college-university:
-                filter: { kind: [university, college, college-university] }
-                draw:   { icons: { sprite: college-university } }
-            zoo:
-                filter: { kind: [zoo] }
-                draw:   { icons: { sprite: zoo } }
 
 
     landuse:
@@ -1582,107 +1081,124 @@ layers:
                 - { $zoom: { min: 14 }, area: { min: 50000 } }
                 - { $zoom: { min: 15 }, area: { min: 20000 } }
                 - { $zoom: { min: 15 }, area: { min: 2000 } }
-                - { $zoom: { min: 16 } }    
+                - { $zoom: { min: 16 } }
         park:
             filter:
                 kind: park
-            draw:
-                polygons:
-                #dots2:
-                    order: 1
-                    color: *green1
+            park_z1:
+                filter:
+                    $zoom: [1,2,3,4,5,6,7,8,9,10,11]
+                draw:
+                    park-dots1:
+                        order: 1
+            park_z12:
+                filter:
+                    $zoom: [12,13,14]
+                draw:
+                    park-dots2:
+                        order: 1
+            park_z15:
+                filter:
+                    $zoom: [15,16,17,18]
+                draw:
+                    park-dots3:
+                        order: 1
         cemetery:
             filter:
                 kind: cemetery
             draw:
-                polygons:
+                park-dots2:
                     order: 2
-                    color: *green2
         forest:
             filter:
                 kind: forest
             draw:
-                polygons:
+                ppark-dots2:
                     order: 1
-                    color: *green7
-        recreation_ground:
+        conservation:
             filter:
-                kind: recreation_ground
+                kind: conservation
             draw:
-                polygons:
+                park-dots2:
                     order: 1
-                    color: *mystry1
-        farm:
-            filter:
-                kind: [farm, farmland]
-                $zoom: { min: 10}
-            draw:
-                polygons:
-                    order: 1
-                    color: [ [10,*green4], [11,*green5] ]
+        # recreation_ground:
+        #     filter:
+        #         kind: recreation_ground
+        #     draw:
+        #         polygons:
+        #             order: 1
+        #             color: *mystry1
+        # farm:
+        #     filter:
+        #         kind: [farm, farmland]
+        #         $zoom: { min: 10}
+        #     draw:
+        #         polygons:
+        #             order: 1
+        #             color: [ [10,*green4], [11,*green5] ]
         golf_course:
             filter:
                 kind: golf_course
             draw:
-                polygons:
+                park-dots2:
                     order: 2
                     color: *green3
         nature_reserve:
             filter:
                 kind: nature_reserve
             draw:
-                polygons:
+                park-dots2:
                     order: 1
                     color: *green6
-        stadium:
-            filter:
-                kind: stadium
-            draw:
-                polygons:
-                    order: 1
-                    color: *orange1
+        # stadium:
+        #     filter:
+        #         kind: stadium
+        #     draw:
+        #         polygons:
+        #             order: 1
+        #             color: *orange1
         university:
             filter:
                 kind: university
             draw:
-                polygons:
+                park-dots2:
                     order: 2
                     color: *brown1
-        school:
-            filter:
-                kind: school
-            draw:
-                polygons:
-                    order: 2
-                    color: *brown2
+        # school:
+        #     filter:
+        #         kind: school
+        #     draw:
+        #         polygons:
+        #             order: 2
+        #             color: *brown2
         hospital:
             filter:
                 kind: hospital
             draw:
-                polygons:
+                park-dots2:
                     order: 2
                     color: *red1
-        playground:
-            filter:
-                kind: playground
-            draw:
-                polygons:
-                    order: 2
-                    color: *brown3
-        pedestrian:
-            filter:
-                kind: pedestrian
-            draw:
-                polygons:
-                    order: 2
-                    color: *grey1
-        retail:
-            filter:
-                kind: retail
-            draw:
-                polygons:
-                    order: 2
-                    color: *grey1
+        # playground:
+        #     filter:
+        #         kind: playground
+        #     draw:
+        #         polygons:
+        #             order: 2
+        #             color: *brown3
+        # pedestrian:
+        #     filter:
+        #         kind: pedestrian
+        #     draw:
+        #         polygons:
+        #             order: 2
+        #             color: *grey1
+        # retail:
+        #     filter:
+        #         kind: retail
+        #     draw:
+        #         polygons:
+        #             order: 2
+        #             color: *grey1
 #        commercial:
 #            filter:
 #                kind: commercial
@@ -1690,13 +1206,38 @@ layers:
 #                polygons:
 #                    order: 2
 #                    color: [0.149, 0.475, 0.851]
+
+        # parking:
+        #     filter:
+        #         kind: parking
+        #     draw:
+        #         polygons:
+        #             order: 2
+        #             color: *grey1
+        # railway:
+        #     filter:
+        #         kind: railway
+        #     draw:
+        #         polygons:
+        #             order: 2
+        #             color: *grey3
+        # place_of_worship:
+        #     filter:
+        #         kind: place_of_worship
+        #     draw:
+        #         polygons:
+        #             order: 2
+        #             color: *grey1
+
+    landuse-not-filtered:
+        data: { source: osm, layer: landuse }
         runway:
             filter:
                 kind: runway
             draw:
                 polygons:
-                    order: 2
-                    color: *grey2
+                    order: 11
+                    color: black
         apron:
             filter:
                 kind: apron
@@ -1704,34 +1245,39 @@ layers:
             draw:
                 polygons:
                     order: 2
-                    color: *grey1
-                    
-        parking:
-            filter:
-                kind: parking
-            draw:
-                polygons:
-                    order: 2
-                    color: *grey1
-        railway:
-            filter:
-                kind: railway
-            draw:
-                polygons:
-                    order: 2
-                    color: *grey3
-        place_of_worship:
-            filter:
-                kind: place_of_worship
-            draw:
-                polygons:
-                    order: 2
-                    color: *grey1
-                    
-    debug:
-        data: { source: osm }
+                    color: [0.95,0.95,0.95]
+
+    buildings-early:
+        data: { source: osm, layer: buildings }
+        filter: { $zoom: { min: 13 } }
+        #filter: { $zoom: { min: 13, max: 18 } }
         draw:
-            flat_lines:
-                width: 2px
-                order: 100
-                color: '#ff0000'
+            polygons:
+                order: 4
+                color: [1.000, 1.000, 1.000]
+            outline:
+                style: lines
+                order: 51
+                color: [[14, [0.8,0.8,0.8]], [15, [0.78,0.78,0.78]], [16, [0.486,0.486,0.486]]]
+                width: [[14,0.3px],[15,0.5px],[16,0.5px],[18,0.5px]]
+                extrude: false
+
+#    buildings-late:
+#        data: { source: osm, layer: buildings }
+#        filter: { $zoom: { min: 18 } }
+#        draw:
+#            polygons:
+#                order: 50
+#                color: [1.000,1.000,1.000]
+#            outline:
+#                style: lines
+#                order: 51
+#                color: [0.486,0.486,0.486]
+#                width: 0.85px
+#                extrude: true
+#        extruded:
+#            filter: { $zoom: { min: 17 } }
+#            draw:
+#                polygons:
+#                    style: buildings_grid
+#                    extrude: function () { return feature.height > 0 || $zoom >= 17; }


### PR DESCRIPTION
This should help improve legibility of gazetteer overlays over the basemap background.

It's the same as what's over at https://github.com/tangrams/multiverse/blob/gh-pages/styles/line-drawing2.yaml with the following exception: buildings aren't extruded at zoom 18+. More work needs to be done with the water coast treatment.