### PR TITLE
Add CORS headers to API search endpoint

### DIFF
--- a/www/server.py
+++ b/www/server.py
@@ -1379,6 +1379,7 @@ def searchify():
 
 @app.route("/api/search", methods=["GET"])
 @app.route("/api/search/", methods=["GET"])
+@cross_origin()
 def api_searchify():
 
     try:


### PR DESCRIPTION
This PR is to enable cross-origin requests to be made to the `/api/search` endpoint.  This is useful for building front-end tooling that consumes the API search endpoint whilst being hosted on other domains.  I'm not sure if this is the intended use-case for this endpoint. If the goal is to allow third-parties to search WOF data by properties, it may be best to expose the ES server to `GET` requests directly (reduced burden on the Python server, lower latency, greater query abilities).

Much of this is duplicate from an email earlier sent to hello@mapzen.com. Apologies if this is redundant.