### PR TITLE
Fixes to JS config example

### DIFF
--- a/www/static/javascript/mapzen.whosonfirst.config.js.example
+++ b/www/static/javascript/mapzen.whosonfirst.config.js.example
@@ -17,6 +17,9 @@ mapzen.whosonfirst.config = (function(){
 				var root = location.protocol + "//" + location.host;
 				endpoint = root + "/data/";
 	    		}
+			else if (endpoint.substr(-1) != "/"){
+				endpoint += "/";
+			}
 
 			mapzen.whosonfirst.uri.endpoint(endpoint);
 
@@ -36,7 +39,7 @@ mapzen.whosonfirst.config = (function(){
 			var api_key = 'XXXXXXXX';
 
 			if (mapzen.whosonfirst.leaflet.tangram) {
-				mapzen.whosonfirst.leaflet.tangram.set_api_key(api_key);
+				mapzen.whosonfirst.leaflet.tangram.set_key('mapzen-' + api_key);
 			}
 
 			// You may want to change this to whosonfirst-api.dev.mapzen.com


### PR DESCRIPTION
Two fixes I had to make to get my local dev env working for #119. These changes are independent of #119, these just help the 'set up new dev env' process move a little smoother.

 * python env expects the 'data root' to [not have a trailing slash](https://github.com/whosonfirst/whosonfirst-www-spelunker/blob/7d96db710456476ae90cd2f131347945b4fda22c/config/whosonfirst-www-spelunker-flask.cfg.example#L11), while the js env [expects it](https://github.com/whosonfirst/js-mapzen-whosonfirst/blob/e965bcaaece0410680398a7d77da2f5c695aa82e/src/mapzen.whosonfirst.uri.js#L23) Obviously there's other fixes possible here but this seemed like the least intrusive.
 * the function `set_api_key` doesn't exist anymore in [`mapzen.whosonfirst.leaflet.tangram.js`](https://github.com/whosonfirst/whosonfirst-www-spelunker/blob/7d96db710456476ae90cd2f131347945b4fda22c/www/static/javascript/mapzen.whosonfirst.leaflet.tangram.js#L263), it's `set_key`, and it expects an API key with the `mapzen-` prefix