### PR TITLE
Visualization of alternate geometries, links to raw alt geom files

### DIFF
--- a/www/server.py
+++ b/www/server.py
@@ -2899,6 +2899,12 @@ def doc_to_geojson(doc):
         path = mapzen.whosonfirst.uri.id2relpath(id)
         properties['wof:path'] = path
 
+    if not properties.get('wof:alt_paths', False):
+        alt_paths = {}
+        for source in properties["src:geom_alt"]:
+	    alt_paths[source] = mapzen.whosonfirst.uri.id2relpath(id, alt=True, source=source)
+        properties['wof:alt_paths'] = alt_paths
+
     if properties.get('geom:bbox', False):
         bbox = properties['geom:bbox']
         bbox = bbox.split(",")

--- a/www/server.py
+++ b/www/server.py
@@ -2901,7 +2901,7 @@ def doc_to_geojson(doc):
 
     if not properties.get('wof:alt_paths', False):
         alt_paths = {}
-        for source in properties["src:geom_alt"]:
+        for source in properties.get("src:geom_alt", []):
 	    alt_paths[source] = mapzen.whosonfirst.uri.id2relpath(id, alt=True, source=source)
         properties['wof:alt_paths'] = alt_paths
 

--- a/www/static/css/mapzen.whosonfirst.spelunker.css
+++ b/www/static/css/mapzen.whosonfirst.spelunker.css
@@ -294,17 +294,14 @@ pre {
     border-radius: 0px !important;
 }
 
-#slippymap-coords:before {
-    content:"the map is currently centered at ";
-}
-
-#slippymap-coords {
+#map-status {
     float: right;
     font-size:.8em;
     color:#666;
     margin-bottom:1em;
 }
 
+#geom-select:hover,
 #slippymap-coords:hover {
     color: #000;
 }

--- a/www/static/javascript/mapzen.whosonfirst.leaflet.js
+++ b/www/static/javascript/mapzen.whosonfirst.leaflet.js
@@ -83,14 +83,17 @@ mapzen.whosonfirst.leaflet = (function(){
 
 		'clear_geom_layers': function(map, layers_to_exclude){
 
-			// to exclude a LayerGroup, we have to exclude all it's childern too
-			var all_exclusions = layers_to_exclude;
-			for (var i = 0; i < layers_to_exclude.length; i++) {
-				var childern = layers_to_exclude[i]._layers;
-				if (childern){
-					all_exclusions = all_exclusions.concat(Object.values(childern));
+			// to exclude a LayerGroup, we have to exclude it's children too
+			// which may be LayerGroups themselves
+			var all_exclusions = [];
+			var add_to_exclusion_list = function(layers){
+				all_exclusions = all_exclusions.concat(layers);
+				for (var i = 0; i < layers.length; i++) {
+					var child_layers = Object.values(layers[i]._layers || {});
+					add_to_exclusion_list(child_layers);
 				}
-			}
+			};
+			add_to_exclusion_list(layers_to_exclude);
 
 			map.eachLayer(function (layer){
 				// leave the title layer

--- a/www/static/javascript/mapzen.whosonfirst.leaflet.js
+++ b/www/static/javascript/mapzen.whosonfirst.leaflet.js
@@ -81,6 +81,29 @@ mapzen.whosonfirst.leaflet = (function(){
 			return self.draw_poly(map, bbox_geojson, style);
 		},
 
+		'clear_geom_layers': function(map, layers_to_exclude){
+
+			// to exclude a LayerGroup, we have to exclude all it's childern too
+			var all_exclusions = layers_to_exclude;
+			for (var i = 0; i < layers_to_exclude.length; i++) {
+				var childern = layers_to_exclude[i]._layers;
+				if (childern){
+					all_exclusions = all_exclusions.concat(Object.values(childern));
+				}
+			}
+
+			map.eachLayer(function (layer){
+				// leave the title layer
+				if (layer instanceof L.TileLayer){
+					return;
+				}
+				if (all_exclusions.indexOf(layer) != -1){
+					return;
+				}
+				map.removeLayer(layer);
+			});
+		},
+
 		'fit_map': function(map, geojson, force){
 
 			var bbox = mapzen.whosonfirst.geojson.derive_bbox(geojson);

--- a/www/static/javascript/mapzen.whosonfirst.uri.js
+++ b/www/static/javascript/mapzen.whosonfirst.uri.js
@@ -61,6 +61,7 @@ mapzen.whosonfirst.uri = (function(){
 		    ];
 
 		    if (args["alt"]) {
+			fname.push('alt');
 
 			if (args["source"]){
 

--- a/www/static/javascript/slippymap.crosshairs.js
+++ b/www/static/javascript/slippymap.crosshairs.js
@@ -41,17 +41,17 @@ slippymap.crosshairs = (function(){
 		var coords = document.createElement("div");
 		coords.setAttribute("id", "slippymap-coords");
 
-		coords.onclick = function(){
-		    latlon = (latlon) ? false : true;
-		    self.draw_coords(map);
-		    return;
-		};
-
 		var container = map.getContainer();
 		var container_el = document.getElementById(container.id);
 
 		container_el.parentNode.insertBefore(coords, container_el.nextSibling); 
 	    }
+
+	    coords.onclick = function(){
+		latlon = (latlon) ? false : true;
+		self.draw_coords(map);
+		return;
+	    };
 
 	    var pos = map.getCenter();
 	    var lat = pos['lat'];
@@ -64,7 +64,7 @@ slippymap.crosshairs = (function(){
 
 	    if (latlon){
 
-		ll = lat.toFixed(6) + ", " + lon.toFixed(6) + " #" + zoom;
+		    ll = lat.toFixed(6) + ", " + lon.toFixed(6) + " #" + zoom.toFixed(2);
 		title = "coordinates are displayed as latitude,longitude – click to toggle";
 	    }
 	    
@@ -111,7 +111,7 @@ slippymap.crosshairs = (function(){
 	    style.push("background-position: center center");
 	    style.push("background-repeat: no-repeat");
 	    style.push("background: url(" + data_url + ")");
-	    style.push("z-index:200");
+	    style.push("z-index:10000");
 	    
 	    style = style.join(";");
 

--- a/www/templates/id.html
+++ b/www/templates/id.html
@@ -161,7 +161,10 @@
 {% if g.enable_feature_bundler %}<li><a href="{{ url_for('index') }}download/{{ doc.properties.get("wof:id") | e }}/?exclude=nullisland">Download descendants of {{ doc.properties.get("wof:name") | e }}</a></li>{% endif %}
 {% endif %}
 
-<li><a href="/data/{{ doc.properties.get("wof:path") |e }}" target="data">Raw data (GeoJSON)</a></li>
+<li><a href="/data/{{ doc.properties.get("wof:path") | e }}" target="data">Raw GeoJSON{% if doc.properties.get("wof:alt_paths") %} for consensus geometry: {{ doc.properties.get("src:geom") | e}}{% endif %}</a></li>
+{% for source, alt_path in doc.properties.get("wof:alt_paths").items() %}
+<li><a href="/data/{{ alt_path | e }}" target="data">Raw GeoJSON for alternate geometry: {{ source }}</a></li>
+{% endfor %}
 
 </ul>
 

--- a/www/templates/id.html
+++ b/www/templates/id.html
@@ -85,6 +85,7 @@
 
 <div class="row">
 <div class="col-md-12" id="map"></div>
+<div id="map-status">The map is displaying the <span id="geom-select"></span> and is centered at <span id="slippymap-coords"></span></div>
 </div>
 
 <div class="row"><small>


### PR DESCRIPTION
Addresses #119 

I went ahead an implemented a select widget under the map. It only appears if the record has alternate geometries. Here's what it looks like on a record with alternates:

<img width="1021" alt="geom-alts-with-select-widget" src="https://user-images.githubusercontent.com/69902/29182898-0f812246-7dd7-11e7-92be-f0dd36671695.png">

Upon changing geometries with the select widget:

 * the parent record's polygon is untouched
 * the bounding box and consensus geometry polygons are removed
 * the markers for the label centroid and center-of-mass are removed
 * new polygons for the alternate geometry's bounding box and geometry are drawn
 * the map zooms and centers itself to match the alternate geom and bounding box

I wasn't sure where exactly to put PR's for changes to two files: `mapzen.whosonfirst.enmapify.js` and `mapzen.whosonfirst.leaflet.js`. Both these files are present in `whosonfirst/js-mapzen-whosonfirst`, but only `enmapify` is pulled in by the Makefile. It appears there's been independent changes in both repos of these files so they're no longer in sync. As such, I've just put the changes here to start but let me know if should open up another PR on `whosonfirst/js-mapzen-whosonfirst`.

This PR also pulls in https://github.com/whosonfirst/js-slippymap-crosshairs/commit/bb40b2b814ae126d8bccc717f641dfed26e93c09 as a consequence of updating slippymap-crosshairs to the latest in it's repo, these changes are technically outside the scope of this PR but AFIAK don't do any harm.