### PR TITLE
Add links to GeoJSON files for alt geoms

### DIFF
--- a/www/server.py
+++ b/www/server.py
@@ -2899,6 +2899,12 @@ def doc_to_geojson(doc):
         path = mapzen.whosonfirst.uri.id2relpath(id)
         properties['wof:path'] = path
 
+    if not properties.get('wof:alt_geom_paths', False):
+        alt_geom_paths = {}
+        for source in properties.get("src:geom_alt", []):
+	    alt_geom_paths[source] = mapzen.whosonfirst.uri.id2relpath(id, alt=True, source=source)
+        properties['wof:alt_geom_paths'] = alt_geom_paths
+
     if properties.get('geom:bbox', False):
         bbox = properties['geom:bbox']
         bbox = bbox.split(",")

--- a/www/templates/id.html
+++ b/www/templates/id.html
@@ -161,7 +161,10 @@
 {% if g.enable_feature_bundler %}<li><a href="{{ url_for('index') }}download/{{ doc.properties.get("wof:id") | e }}/?exclude=nullisland">Download descendants of {{ doc.properties.get("wof:name") | e }}</a></li>{% endif %}
 {% endif %}
 
-<li><a href="/data/{{ doc.properties.get("wof:path") |e }}" target="data">Raw data (GeoJSON)</a></li>
+<li><a href="/data/{{ doc.properties.get("wof:path") | e }}" target="data">Raw GeoJSON{% if doc.properties.get("wof:alt_geom_paths") %} for consensus geometry: {{ doc.properties.get("src:geom") | e}}{% endif %}</a></li>
+{% for source, alt_geom_path in doc.properties.get("wof:alt_geom_paths").items() %}
+<li><a href="/data/{{ alt_geom_path | e }}" target="data">Raw GeoJSON for alternate geometry: {{ source }}</a></li>
+{% endfor %}
 
 </ul>
 


### PR DESCRIPTION
Addresses part of #119 

This PR adds links to the raw GeoJSON files for alternate geometries, like so:

![new-raw-geojson-links](https://user-images.githubusercontent.com/69902/29466818-a2784848-8414-11e7-8a4b-ce2f8d702af4.png)

For records that don't have alternate geometries, there's just one link that says _Raw GeoJSON_