### PR TITLE
Vizualization of alternate geometries

### DIFF
--- a/www/static/css/mapzen.whosonfirst.spelunker.css
+++ b/www/static/css/mapzen.whosonfirst.spelunker.css
@@ -294,17 +294,14 @@ pre {
     border-radius: 0px !important;
 }
 
-#slippymap-coords:before {
-    content:"the map is currently centered at ";
-}
-
-#slippymap-coords {
+#map-status {
     float: right;
     font-size:.8em;
     color:#666;
     margin-bottom:1em;
 }
 
+#geom-select:hover,
 #slippymap-coords:hover {
     color: #000;
 }

--- a/www/static/javascript/mapzen.whosonfirst.leaflet.js
+++ b/www/static/javascript/mapzen.whosonfirst.leaflet.js
@@ -81,6 +81,32 @@ mapzen.whosonfirst.leaflet = (function(){
 			return self.draw_poly(map, bbox_geojson, style);
 		},
 
+		'clear_geom_layers': function(map, layers_to_exclude){
+
+			// to exclude a LayerGroup, we have to exclude it's children too
+			// which may be LayerGroups themselves
+			var all_exclusions = [];
+			var add_to_exclusion_list = function(layers){
+				all_exclusions = all_exclusions.concat(layers);
+				for (var i = 0; i < layers.length; i++) {
+					var child_layers = Object.values(layers[i]._layers || {});
+					add_to_exclusion_list(child_layers);
+				}
+			};
+			add_to_exclusion_list(layers_to_exclude);
+
+			map.eachLayer(function (layer){
+				// leave the title layer
+				if (layer instanceof L.TileLayer){
+					return;
+				}
+				if (all_exclusions.indexOf(layer) != -1){
+					return;
+				}
+				map.removeLayer(layer);
+			});
+		},
+
 		'fit_map': function(map, geojson, force){
 
 			var bbox = mapzen.whosonfirst.geojson.derive_bbox(geojson);

--- a/www/static/javascript/mapzen.whosonfirst.uri.js
+++ b/www/static/javascript/mapzen.whosonfirst.uri.js
@@ -61,6 +61,7 @@ mapzen.whosonfirst.uri = (function(){
 		    ];
 
 		    if (args["alt"]) {
+			fname.push('alt');
 
 			if (args["source"]){
 

--- a/www/static/javascript/slippymap.crosshairs.js
+++ b/www/static/javascript/slippymap.crosshairs.js
@@ -41,17 +41,17 @@ slippymap.crosshairs = (function(){
 		var coords = document.createElement("div");
 		coords.setAttribute("id", "slippymap-coords");
 
-		coords.onclick = function(){
-		    latlon = (latlon) ? false : true;
-		    self.draw_coords(map);
-		    return;
-		};
-
 		var container = map.getContainer();
 		var container_el = document.getElementById(container.id);
 
 		container_el.parentNode.insertBefore(coords, container_el.nextSibling); 
 	    }
+
+	    coords.onclick = function(){
+		latlon = (latlon) ? false : true;
+		self.draw_coords(map);
+		return;
+	    };
 
 	    var pos = map.getCenter();
 	    var lat = pos['lat'];
@@ -64,7 +64,7 @@ slippymap.crosshairs = (function(){
 
 	    if (latlon){
 
-		ll = lat.toFixed(6) + ", " + lon.toFixed(6) + " #" + zoom;
+		    ll = lat.toFixed(6) + ", " + lon.toFixed(6) + " #" + zoom.toFixed(2);
 		title = "coordinates are displayed as latitude,longitude – click to toggle";
 	    }
 	    
@@ -111,7 +111,7 @@ slippymap.crosshairs = (function(){
 	    style.push("background-position: center center");
 	    style.push("background-repeat: no-repeat");
 	    style.push("background: url(" + data_url + ")");
-	    style.push("z-index:200");
+	    style.push("z-index:10000");
 	    
 	    style = style.join(";");
 

--- a/www/templates/id.html
+++ b/www/templates/id.html
@@ -85,6 +85,7 @@
 
 <div class="row">
 <div class="col-md-12" id="map"></div>
+<div id="map-status">The map is displaying the <span id="geom-select"></span> and is centered at <span id="slippymap-coords"></span></div>
 </div>
 
 <div class="row"><small>


### PR DESCRIPTION
Addresses part of #119 

This PR adds, for records that have alternate geometries, a selector widget under the map that allows the user to choose which geometry they'd like to see a visual of. Ex:

![new-alt-geom-visualization-selector](https://user-images.githubusercontent.com/69902/29466988-451533a4-8415-11e7-8ec5-465e58bbda40.png)

For records that don't have alternate geometries, the behavior is unchanged.

I wasn't sure where exactly to put PR's for changes to two files: `mapzen.whosonfirst.enmapify.js` and `mapzen.whosonfirst.leaflet.js`. Both these files are present in `whosonfirst/js-mapzen-whosonfirst`, but only `mapzen.whosonfirst.enmapify.js` is pulled in by the Makefile. It appears there's been independent changes in both repos of these files so they're no longer in sync. As such, I've just put the changes here to start but let me know if it would be helpful if I open up another PR on `whosonfirst/js-mapzen-whosonfirst`.

This PR also pulls in whosonfirst/js-slippymap-crosshairs@bb40b2b as a consequence of updating slippymap-crosshairs to the latest in it's repo, these changes are technically outside the scope of this PR but AFIAK don't do any harm.