### PR TITLE
Add Write Field edit link to sidebar

### DIFF
--- a/www/templates/id.html
+++ b/www/templates/id.html
@@ -187,7 +187,8 @@
 
 <li><a href="https://data.whosonfirst.org/{{ doc.properties.get("wof:path") |e }}" target="data">Raw data (GeoJSON)</a></li>
 <li><a href="https://github.com/whosonfirst-data/{{ doc.properties.get("wof:repo") |e }}/blob/master/data/{{ doc.properties.get("wof:path") |e }}" target="github">View on Github</a></li>
-
+<li><a href="https://writefield.nextzen.org/place/edit?url=https://raw.githubusercontent.com/whosonfirst-data/{{ doc.properties.get("wof:repo") |e }}/master/data/{{ doc.properties.get("wof:path") |e }}" target="writefield">Edit in Write Field</a></li>
+	
 </ul>
 
 {% include "inc_log.html" %}


### PR DESCRIPTION
This change should add a new link in the sidebar to Edit the currently viewed place in Write Field for simple property edits.

Relates to https://github.com/iandees/wof-editor/issues/60.

![image](https://user-images.githubusercontent.com/853051/232183026-515d7bb5-fc88-4f53-8fb6-6673d360bc45.png)